### PR TITLE
[Refactor] : fullButton, searchInput 리팩토링

### DIFF
--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -5,16 +5,17 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   color: 'status_red1' | 'primary_orange1' | 'white' | 'grey5' | 'black'
   bgColor: 'primary_orange1' | 'primary_orange2' | 'black' | 'grey2' | 'white' | 'red'
   content: string;
+  className?: string;
 }
 
-export default function FullButton({ size, color, bgColor, content, ...props }: ButtonProps) {
+export default function FullButton({ size, color, bgColor, content, className, ...props }: ButtonProps) {
   return (
-    <button className={cn(`w-full cursor-pointer text-${color} bg-${bgColor} flex justify-center items-center rounded-md shadow-mypageButton`,
+    <button className={cn(`w-full cursor-pointer text-${color} bg-${bgColor} flex justify-center items-center rounded-md`,
       {
         'body4 h-[37px]': size === 'sm',
         'title3 h-[44px]': size === 'md',
         'title3 h-[50px]': size === 'lg'
       }
-    )} {...props}>{content}</button>
+    ,className)} {...props}>{content}</button>
   )
 }

--- a/src/components/all/SearchInput.tsx
+++ b/src/components/all/SearchInput.tsx
@@ -3,10 +3,12 @@ import { cn } from '@utils/cn';
 
 interface SearchInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   result?: boolean;
+  className?: string;
 }
 
 export default function SearchInput({
   result = false,
+  className,
   ...props
 }: SearchInputProps) {
   return (
@@ -17,7 +19,7 @@ export default function SearchInput({
         className={cn('grow bg-grey2', {
           'placeholder-grey7': result,
           'placeholder-grey5': !result,
-        })}
+        },className)}
         {...props}
       />
     </div>


### PR DESCRIPTION
## 🕹️ 개요
FullButton, SearchInput 컴포넌트에 className 추가해서 twMerge를 활용해 확장성있게 사용가능하도록 수정

## 🔎 작업 사항
```ts
<FullButton
        size="md"
        bgColor="primary_orange1"
        color="white"
        content="예약하기"
/>
```
이렇게 사용하다 px 어긋나거나 shadow 줘야하면
```ts
<FullButton
        size="md"
        bgColor="primary_orange1"
        color="white"
        content="예약하기"
        className='shadow-mypageButton'
/>
```
다른 컴포넌트처럼 className으로 추가 가능
두 컴포넌트에서 twMerge를 사용하지 않고 있었는데 사용하게 리팩토링.
버튼에서 shadow는 변수가 많은 거 같아 고정으로 부여하지 않고 필요할때 사용하는게 편할 거 같아서 수정함

## 📋 작업 브랜치
fix/buttonWithInput
