### PR TITLE
wish list, reservation-list, mypage 페이지 UI 완성

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,11 @@
-import NavBar from "@components/all/NavBar/NavBar";
+import NavBar from '@components/all/NavBar/NavBar';
 import My from '@components/mypage/My';
+import NoneArrowHeader from '@components/all/NoneArrowHeader';
 
 export default function page() {
   return (
-    <div>
-      This is my profile page
+    <div className="flex flex-col h-full pb-[54px] items-center">
+      <NoneArrowHeader title="마이페이지" />
       <My />
       <NavBar />
     </div>

--- a/src/app/reservation-list/page.tsx
+++ b/src/app/reservation-list/page.tsx
@@ -9,6 +9,7 @@ import {
   HistoryEndItemProps,
 } from 'types/reservation-list/ReservationListPageTypes';
 import NoneResultUI from '@components/all/NoneResultUI/NoneResultUI';
+import NoneArrowHeader from '@components/all/NoneArrowHeader';
 
 const MockReservationInProgressDataArray: HistoryInProgressItemProps[] = [
   {
@@ -77,13 +78,50 @@ const MockReservationEndDataArray: HistoryEndItemProps[] = [
     adultCount: 8,
     isReviewed: true,
   },
+  {
+    companyName: '스카이락볼링장',
+    companyAddress: '서울 서대문구 신촌로 73',
+    eventDate: '05.05 (일)',
+    eventStartTime: '오전 10:00',
+    eventEndTime: '오전 11:00',
+    adultCount: 8,
+    isReviewed: true,
+  },
+  {
+    companyName: '스카이락볼링장',
+    companyAddress: '서울 서대문구 신촌로 73',
+    eventDate: '05.05 (일)',
+    eventStartTime: '오전 10:00',
+    eventEndTime: '오전 11:00',
+    adultCount: 8,
+    isReviewed: true,
+  },
+  {
+    companyName: '스카이락볼링장',
+    companyAddress: '서울 서대문구 신촌로 73',
+    eventDate: '05.10 (수)',
+    eventStartTime: '오전 10:00',
+    eventEndTime: '오전 11:00',
+    adultCount: 8,
+    isReviewed: false,
+  },
+  {
+    companyName: '스카이락볼링장',
+    companyAddress: '서울 서대문구 신촌로 73',
+    eventDate: '05.05 (일)',
+    eventStartTime: '오전 10:00',
+    eventEndTime: '오전 11:00',
+    adultCount: 8,
+    isReviewed: true,
+  },
 ];
 export default function Page() {
   const [historyHeadState, setHistoryHeadState] = useState<
     '전체' | '진행중' | '종료된'
   >('전체');
   return (
-    <div className="h-full pb-[54px] overflow-y-scroll">
+    <div className="flex flex-col h-full pb-[54px] items-center">
+      <NoneArrowHeader title="예약내역" />
       <HistoryHead
         totalCount={5}
         inProgressCount={3}
@@ -92,7 +130,7 @@ export default function Page() {
         handleHeadState={setHistoryHeadState}
       />
       {historyHeadState === '전체' && (
-        <main className="w-full h-full mt-2 flex flex-col justify-start items-center gap-y-[10px] overflow-y-scroll">
+        <main className="w-full h-full flex flex-col top-[94px] justify-center items-center gap-y-[10px] overflow-y-scroll">
           <NoneResultUI
             message="예약 내역이 없어요"
             subMessage="마음에 드는 장소를 찾아 예약해보세요!"
@@ -100,7 +138,7 @@ export default function Page() {
         </main>
       )}
       {historyHeadState === '진행중' && (
-        <main className="w-full h-full flex flex-col justify-start items-center gap-y-[10px] overflow-y-scroll">
+        <main className="w-full max-h-reservationListMain py-5 flex flex-col top-[94px] absolute justify-start items-center gap-y-[10px] overflow-y-scroll">
           {MockReservationInProgressDataArray.map((data, index) => (
             <HistoryInProgressItem
               key={index}
@@ -117,7 +155,7 @@ export default function Page() {
       )}
 
       {historyHeadState === '종료된' && (
-        <main className="w-full h-full flex flex-col justify-start items-center gap-y-[10px] overflow-y-scroll">
+        <main className="w-full max-h-reservationListMain py-5 flex flex-col top-[94px] absolute justify-start items-center gap-y-[10px] overflow-y-scroll">
           {MockReservationEndDataArray.map((data, index) => (
             <HistoryEndItem
               key={index}

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,13 +1,137 @@
-import NavBar from "@components/all/NavBar/NavBar";
+import NavBar from '@components/all/NavBar/NavBar';
 import Tabs from '@components/all/Tabs/Tabs';
 import { allleisureArray } from '@constant/constant';
+import NoneArrowHeader from '@components/all/NoneArrowHeader';
+import { ResultCardProps } from 'types/search/result/searchResult';
+import ResultCard from '@components/search/result/ResultCard';
+import { da } from 'date-fns/locale';
+
+const DUMMYRESULTS: ResultCardProps[] = [
+  {
+    clubName: '스카이락볼링장1',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장2',
+    location:
+      '서울특별시 강남구 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장3',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장4',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장5',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장6',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장7',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장8',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장9',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+  {
+    clubName: '스카이락볼링장10',
+    location: '서울특별시 강남구 역삼동',
+    rating: 4.5,
+    reviewCount: 100,
+    price: '10,000원',
+    gameType: '게임',
+    isEvent: true,
+    isHeart: true,
+    image: '/png/dummyImage.png',
+  },
+];
 
 export default function page() {
   const tabArray = allleisureArray;
   return (
-    <div>
-      <Tabs tabArray={tabArray} rounded from="wishlist" />
-      This is wish list page
+    <div className="flex flex-col h-full items-center relative">
+      <NoneArrowHeader title="위시리스트" />
+      <Tabs
+        tabArray={tabArray}
+        rounded
+        from="wishlist"
+        className="w-fit px-5 top-[44px] border-b-[1px] border-grey2"
+      />
+
+      <main className="w-full h-full absolute top-[97px] mt-5 overflow-y-scroll">
+        {DUMMYRESULTS.map((data, index) => (
+          <ResultCard key={index} {...data} />
+        ))}
+      </main>
+
       <NavBar />
     </div>
   );

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -117,7 +117,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
 export default function page() {
   const tabArray = allleisureArray;
   return (
-    <div className="flex flex-col h-full items-center relative">
+    <div className="flex flex-col h-full mb-[54px] items-center ">
       <NoneArrowHeader title="위시리스트" />
       <Tabs
         tabArray={tabArray}
@@ -126,7 +126,7 @@ export default function page() {
         className="w-fit px-5 top-[44px] border-b-[1px] border-grey2"
       />
 
-      <main className="w-full h-full absolute top-[97px] mt-5 overflow-y-scroll">
+      <main className="w-full max-h-wishListMain  absolute top-[97px] mt-5 pb-5 overflow-y-scroll">
         {DUMMYRESULTS.map((data, index) => (
           <ResultCard key={index} {...data} />
         ))}

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -117,7 +117,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
 export default function page() {
   const tabArray = allleisureArray;
   return (
-    <div className="flex flex-col h-full mb-[54px] items-center ">
+    <div className="flex flex-col h-full mb-[54px] items-center">
       <NoneArrowHeader title="위시리스트" />
       <Tabs
         tabArray={tabArray}

--- a/src/components/all/NoneArrowHeader.tsx
+++ b/src/components/all/NoneArrowHeader.tsx
@@ -1,0 +1,12 @@
+// 해당 컴포넌트는 위시리스트, 마이페이지 등에서 쓰이는 화살표 없는 헤더를 구현하기 위해 만듬
+interface NoneArrowHeaderProps {
+  title: string;
+}
+
+export default function NoneArrowHeader({ title }: NoneArrowHeaderProps) {
+  return (
+    <header className="w-full h-[44px] flex justify-start items-center pl-5 title1 text-grey7 absolute top-0">
+      <span>{title}</span>
+    </header>
+  );
+}

--- a/src/components/all/NoneResultUI/NoneResultUI.tsx
+++ b/src/components/all/NoneResultUI/NoneResultUI.tsx
@@ -1,11 +1,23 @@
+import { cn } from '@utils/cn';
+
 interface NoneUIProps {
   message: string;
   subMessage: string;
+  className?: string;
 }
 
-export default function NoneResultUI({ message, subMessage }: NoneUIProps) {
+export default function NoneResultUI({
+  message,
+  subMessage,
+  className,
+}: NoneUIProps) {
   return (
-    <div className="w-fit h-[46px] flex flex-col justify-between items-center gap-y-[10px]">
+    <div
+      className={cn(
+        'w-fit h-[46px] flex flex-col justify-between items-center gap-y-[10px]',
+        className
+      )}
+    >
       <span className="title2 text-grey7">{message}</span>
       <span className="caption1 text-grey5">{subMessage}</span>
     </div>

--- a/src/components/all/Tabs/Tab.tsx
+++ b/src/components/all/Tabs/Tab.tsx
@@ -14,7 +14,7 @@ export default function Tab({
   TabNumber,
   name,
   className,
-  rounded = false
+  rounded = false,
 }: TabProps) {
   const currentTab = useTab((state) => state.selectedTab);
   const setCurrentTab = useTab((state) => state.setSelectedTab);
@@ -23,21 +23,23 @@ export default function Tab({
       className={cn(
         'flex justify-center items-center relative cursor-pointer title3',
         {
-          'text-primary_orange1': (currentTab === TabNumber) && !rounded,
-          'text-grey6': (currentTab !== TabNumber) && !rounded,
-          'text-white h-[30px] bg-primary_orange1 border border-primary_orange1': (currentTab === TabNumber) && rounded,
-          'text-grey6 h-[30px] border border-grey3': (currentTab !== TabNumber) && rounded,
+          'text-primary_orange1': currentTab === TabNumber && !rounded,
+          'text-grey6': currentTab !== TabNumber && !rounded,
+          'text-white h-[30px] bg-primary_orange1 border border-primary_orange1':
+            currentTab === TabNumber && rounded,
+          'text-grey6 h-[30px] border border-grey3':
+            currentTab !== TabNumber && rounded,
           'w-full': !rounded,
           'w-fit rounded-[50px] px-[14px] py-[10px] shrink-0': rounded,
-          'ml-[20px]': (TabNumber === 0) && rounded
         },
         className
       )}
       onClick={() => setCurrentTab(TabNumber)}
     >
       {name}
-        {!rounded && currentTab === TabNumber && (
-          <motion.div layoutId="underline"
+      {!rounded && currentTab === TabNumber && (
+        <motion.div
+          layoutId="underline"
           className={cn(
             'w-full h-[1px] absolute bottom-0',
             {
@@ -46,7 +48,8 @@ export default function Tab({
             },
             className
           )}
-        />)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/mypage/My.tsx
+++ b/src/components/mypage/My.tsx
@@ -4,7 +4,7 @@ import ToastUI from './ToastUI';
 
 export default function My() {
   return (
-    <div className="w-full flex flex-col items-center">
+    <div className="w-full flex flex-col items-center absolute top-[44px] pt-5">
       <div className="w-mypageWidth h-fit flex flex-col items-center gap-y-[30px] mb-[30px]">
         <MyProfileDefaultImage />
         <ProfileInformation />

--- a/src/components/reservation-list/HistoryHead.tsx
+++ b/src/components/reservation-list/HistoryHead.tsx
@@ -57,7 +57,7 @@ export default function HistoryHead({
   // 현재 각 아이템을 클릭하며 테스트하기 위한 용도이고, 추후에 전역 상태로 바뀌어 관련 다른 UI과 조화될 수 있음
 
   return (
-    <div className="w-full h-[49px] px-5 flex justify-start items-center gap-x-5">
+    <div className="w-full h-[49px] px-5 flex justify-start items-center gap-x-5 absolute top-[44px] border-b-[1px] border-grey2">
       <HistoryHeadItem
         label="전체"
         count={totalCount}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,9 @@ const config: Config = {
         eightNineWidth: 'calc(100% * (8/9))',
         sevenEightWidth: 'calc(100% * (7/8))',
       },
+      maxHeight: {
+        wishListMain: 'calc(100% - 151px)',
+      },
       boxShadow: {
         mypageButton: '0 0 0 1px #292A2B inset',
         myPageLogoutButton: '0 0 0 1px #A9AFB3 inset',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,7 +32,9 @@ const config: Config = {
       },
       maxHeight: {
         wishListMain: 'calc(100% - 151px)',
+        reservationListMain: 'calc(100% - 148px)',
       },
+      minHeight: {},
       boxShadow: {
         mypageButton: '0 0 0 1px #292A2B inset',
         myPageLogoutButton: '0 0 0 1px #A9AFB3 inset',


### PR DESCRIPTION
## 🕹️ 개요
해당 페이지들의 UI 완성 및 다양한 환경에서 정상적으로 동작하도록!

## 🔎 작업 사항
1. min-height, max-height 등의 속성을 활용해 스크롤이 자연스러울 수 있도록 구성
2. /wishlist 페이지에서 사용한 Tabs 컴포넌트는 rounded인데, 480px에서는 중앙 정렬되도록 하고(부모 컨테이너 flex의 `items-center`를 활용), 작은 너비 화면에서는  px-5 속성을 통해 양옆에 적당한 여백을 두도록 만듦

## 📋 작업 브랜치
