### PR TITLE
Fix/bottomsheet 

### DIFF
--- a/src/components/all/NavBar/NavBar.tsx
+++ b/src/components/all/NavBar/NavBar.tsx
@@ -37,7 +37,7 @@ export default function NavBar() {
     },
   ];
   return (
-    <section className="w-full h-[54px] bg-white flex justify-around items-center border-t absolute bottom-0">
+    <section className="w-full h-[54px] bg-white flex justify-around items-center border-t absolute bottom-0 z-20">
       {NavLists.map((navItem) => (
         <NavItem
           key={navItem.path}

--- a/src/components/all/SearchHeader.tsx
+++ b/src/components/all/SearchHeader.tsx
@@ -1,6 +1,7 @@
 import TigSVG from '@public/svg/tig.svg';
 import SearchInput from './SearchInput';
 import { cn } from '@utils/cn';
+import Link from 'next/link';
 
 interface SearchHeaderProps {
   placeholder?: string;
@@ -13,7 +14,9 @@ export default function SearchHeader({
 }: SearchHeaderProps) {
   return (
     <section className="w-full py-[2px] px-4 bg-white flex items-center gap-4 absolute top-0">
-      <TigSVG />
+      <Link href={'/'} className="shrink-0 cursor-pointer">
+        <TigSVG  />
+      </Link>
       <SearchInput
         placeholder={placeholder}
         className={cn('grow mr-1 ', {

--- a/src/components/search/result/BottomSheet.tsx
+++ b/src/components/search/result/BottomSheet.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Sheet } from 'react-modal-sheet';
 import { ResultCardProps } from 'types/search/result/searchResult';
 import ResultCard from './ResultCard';
+import NavBar from '@components/all/NavBar/NavBar';
 
 interface BottomSheetProps {
   results: ResultCardProps[];
@@ -10,20 +11,33 @@ interface BottomSheetProps {
 
 export default function BottomSheet({ results }: BottomSheetProps) {
   const [isOpen, setOpen] = useState(false);
-  const { innerHeight: height } = window;
+  const [height, setHeight] = useState<number>(500);
+
+  useEffect(() => {
+    function updateSnapPoints() {
+      const calculateHeight = window.innerHeight- 112;
+      setHeight(calculateHeight);
+    }
+    updateSnapPoints();
+    window.addEventListener('resize', updateSnapPoints);
+    return () => {
+      window.removeEventListener('resize', updateSnapPoints);
+    };
+  }, []);
+  
   return (
     <Sheet
-      className="mx-auto w-full min-w-[360px] max-w-[480px]"
+      className="mx-auto w-full min-w-[360px] max-w-[480px] !z-10"
       isOpen={true}
       // close 할일은 없지만 필수로 넣어야 함
       onClose={() => setOpen(false)}
       initialSnap={1}
       // 0: full screen, 1: 컨텐츠 한 개만, 2: 바텀시트 헤더만
-      snapPoints={[innerHeight - 112, 210, 50]}
+      snapPoints={[height, 264, 104]}
     >
-      <Sheet.Container>
+      <Sheet.Container className='relative h-full w-full'>
         <Sheet.Header className="shadow-none" />
-        <Sheet.Content className='overflow-y-scroll'>
+        <Sheet.Content className='overflow-y-scroll z-10 h-full w-full relative !grow-0' disableDrag={true}>
           {results.map((result) => (
             <ResultCard key={result.clubName} {...result} />
           ))}

--- a/src/components/search/result/ResultCard.tsx
+++ b/src/components/search/result/ResultCard.tsx
@@ -18,7 +18,7 @@ export default function ResultCard({
   image,
 }: ResultCardProps) {
   return (
-    <article className="w-full h-[168px] flex gap-4 p-5 border-b border-grey2">
+    <article className="w-full h-[168px] flex gap-4 p-5 border-b border-grey2 max-w-[480px] min-w-[360px]">
       <div className="relative shrink-0">
         <Image
           src={image}
@@ -38,7 +38,7 @@ export default function ResultCard({
           <div className="w-full flex flex-col gap-1">
             <p className="title3 text-grey7">{clubName}</p>
             {/* max-w 조금 더 최적화 필요할 듯 */}
-            <p className="body4 text-grey5 truncate max-w-[250px]">{location}</p>
+            <p className="body4 text-grey5 truncate max-w-[180px]">{location}</p>
           </div>
           <div className="flex gap-[6px] h-[25px]">
             <p className="bg-primary_orange2 text-primary_orange1 title4 gap-[2px] w-[44px] h-[25px] flex justify-center items-center">


### PR DESCRIPTION
## 🕹️ 개요
이슈해결 close #23 

## 🔎 작업 사항
SearchHeader - 아이콘 `shrink-0`부여 및 클릭 시 홈으로 이동
NavBar - `z-index` 부여
바텀시트 - 라이브러리에 적용된 `z-index:999999` 때문에 NavBar가 안 보이던거 !import로 `z-index` 조정, RSC에서 window 못읽는 문제 useEffect()를 사용해 해결
ResultCard - 바텀시트컨텐츠가 좌우로 움직이던 문제 해결. 디자인과 결정해서 추후 변경할 수도 있음

## 📋 작업 브랜치
