### PR TITLE
Feat/payment before

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,3 +85,16 @@ a {
 .writingReviewButton {
   @apply w-eightNineWidth !important;
 }
+
+@layer utilities {
+  .reservation-stage-item::after {
+    content: '';
+    display: block;
+    width: 40px;
+    height: 1px; /* 실선의 두께 설정 */
+    background-color: #ced3d6;
+    position: absolute;
+    left: 24px;
+    transform: translateY(-50%);
+  }
+}

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -1,11 +1,31 @@
 import Header from '@components/all/Header';
 import ReservationStageBar from '@components/payment/before/ReservationStageBar';
+import BeforeFirstStageCard from '@components/payment/before/BeforeFirstStageCard';
+import FullButton from '@components/all/FullButton';
+
+const DUMMYFIRSTSTAGEDATA = {
+  companyName: '스카이락 볼링장',
+  companyAddress: '서울 서대문구 신촌로 73 케이스퀘어 8층',
+  eventDate: '05.17 (금)',
+  adultCount: 2,
+  eventStartTime: '오전 10:00',
+  eventEndTime: '오전 11:00',
+  stageFirstPrice: 22000,
+};
 
 export default function page() {
   return (
-    <main className="w-full h-full bg-grey1">
+    <main className="w-full h-full flex flex-col items-center bg-grey1">
       <Header buttonType="close" isCenter title="예약확인" bgColor="grey" />
       <ReservationStageBar />
+      <BeforeFirstStageCard {...DUMMYFIRSTSTAGEDATA} />
+      <FullButton
+        size="lg"
+        color="white"
+        bgColor="primary_orange1"
+        content="확인"
+        className="absolute !w-eightNineWidth bottom-[30px]"
+      />
     </main>
   );
 }

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -1,7 +1,10 @@
+'use client';
 import Header from '@components/all/Header';
 import ReservationStageBar from '@components/payment/before/ReservationStageBar';
 import BeforeFirstStageCard from '@components/payment/before/BeforeFirstStageCard';
+import BeforeSecondStageCard from '@components/payment/before/BeforeSecondStageCard';
 import FullButton from '@components/all/FullButton';
+import useReservationStage from '@store/reservationStageStore';
 
 const DUMMYFIRSTSTAGEDATA = {
   companyName: '스카이락 볼링장',
@@ -13,19 +16,55 @@ const DUMMYFIRSTSTAGEDATA = {
   stageFirstPrice: 22000,
 };
 
-export default function page() {
+const DUMMYSECONDSTAGEDATA = {
+  userName: '김티그',
+  phoneNumber: null,
+  couponDiscountPrice: 0,
+  defaultPrice: 22000,
+};
+
+export default function Page() {
+  const reservationStageState = useReservationStage(
+    (state) => state.reservationStage
+  );
   return (
-    <main className="w-full h-full flex flex-col items-center bg-grey1">
-      <Header buttonType="close" isCenter title="예약확인" bgColor="grey" />
-      <ReservationStageBar />
-      <BeforeFirstStageCard {...DUMMYFIRSTSTAGEDATA} />
-      <FullButton
-        size="lg"
-        color="white"
-        bgColor="primary_orange1"
-        content="확인"
-        className="absolute !w-eightNineWidth bottom-[30px]"
+    <main className="w-full h-full flex flex-col items-center bg-grey1 pb-[100px] overflow-y-scroll">
+      <Header
+        buttonType="close"
+        isCenter
+        title="예약확인"
+        bgColor="grey"
+        className="z-10"
       />
+      <ReservationStageBar />
+      {reservationStageState === 1 && (
+        <BeforeFirstStageCard {...DUMMYFIRSTSTAGEDATA} />
+      )}
+
+      {reservationStageState === 2 && (
+        <BeforeSecondStageCard {...DUMMYSECONDSTAGEDATA} />
+      )}
+
+      {reservationStageState === 1 && (
+        <FullButton
+          size="lg"
+          color="white"
+          bgColor="primary_orange1"
+          content="확인"
+          className="absolute !w-eightNineWidth bottom-[30px]"
+          clickTask="move-to-second-payment-stage"
+        />
+      )}
+
+      {reservationStageState === 2 && (
+        <FullButton
+          size="lg"
+          color="white"
+          bgColor="primary_orange1"
+          content="확인"
+          className="absolute !w-eightNineWidth bottom-[30px]"
+        />
+      )}
     </main>
   );
 }

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -1,10 +1,11 @@
 import Header from '@components/all/Header';
-
+import ReservationStageBar from '@components/payment/before/ReservationStageBar';
 
 export default function page() {
   return (
-    <div>
-      <Header buttonType="close" isCenter title="예약확인" bgColor="grey"/>
-    </div>
-  )
+    <main className="w-full h-full bg-grey1">
+      <Header buttonType="close" isCenter title="예약확인" bgColor="grey" />
+      <ReservationStageBar />
+    </main>
+  );
 }

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { cn } from '@utils/cn';
 import { useRouter } from 'next/navigation';
+import useReservationStage from '@store/reservationStageStore';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -25,7 +26,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   clickTask?:
     | 'move-to-writing-review-page'
     | 'move-to-written-review-page'
-    | 'move-to-home-page';
+    | 'move-to-home-page'
+    | 'move-to-second-payment-stage';
   sendingData?: {
     reviewId?: number;
     reservationId?: number;
@@ -43,6 +45,9 @@ export default function FullButton({
   ...props
 }: ButtonProps) {
   const router = useRouter();
+  const setReservationStageStatus = useReservationStage(
+    (state) => state.setReservationStage
+  );
   const colorClasses = {
     status_red1: 'text-status_red1',
     primary_orange1: 'text-primary_orange1',
@@ -76,6 +81,9 @@ export default function FullButton({
     }
     if (clickTask === 'move-to-home-page') {
       router.push('/');
+    }
+    if (clickTask === 'move-to-second-payment-stage') {
+      setReservationStageStatus(2);
     }
   }
 

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -24,7 +24,7 @@ export default function BeforeFirstStageCard({
   return (
     <section className="w-eightNineWidth h-fit rounded-[10px] flex justify-center bg-white mt-[30px] py-5">
       <div className="w-sevenEightWidth h-fit flex flex-col gap-y-5">
-        <p className="w-full h-fit flex flex-col items-start">
+        <p className="w-full h-fit flex flex-col gap-y-1 items-start">
           <span className="title3 text-grey7">{companyName}</span>
           <span className="body4 text-grey5">{companyAddress}</span>
         </p>

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -1,0 +1,64 @@
+interface BeforeFirstStageCardProps {
+  companyName: string;
+  companyAddress: string;
+  eventDate: string;
+  adultCount?: number;
+  youngManCount?: number;
+  kidCount?: number;
+  eventStartTime: string;
+  eventEndTime: string;
+  stageFirstPrice: number;
+}
+
+export default function BeforeFirstStageCard({
+  companyName,
+  companyAddress,
+  eventDate,
+  adultCount,
+  youngManCount,
+  kidCount,
+  eventStartTime,
+  eventEndTime,
+  stageFirstPrice,
+}: BeforeFirstStageCardProps) {
+  return (
+    <section className="w-eightNineWidth h-fit rounded-[10px] flex justify-center bg-white mt-[30px] py-5">
+      <div className="w-sevenEightWidth h-fit flex flex-col gap-y-5">
+        <p className="w-full h-fit flex flex-col items-start">
+          <span className="title3 text-grey7">{companyName}</span>
+          <span className="body4 text-grey5">{companyAddress}</span>
+        </p>
+        <div className="w-full border-b-[1px] border-grey2" />
+        <div className="w-full flex justify-between items-center">
+          <span className="title text-grey4">날짜</span>
+          <span className="body4 text-grey6">{eventDate}</span>
+        </div>
+        <div className="w-full flex justify-between items-center">
+          <span className="title text-grey4">인원</span>
+          <span className="body4 text-grey6">
+            {adultCount && `성인 ${adultCount}명 `}{' '}
+            {youngManCount && `청소년 ${youngManCount}명 `}{' '}
+            {kidCount && `어린이 ${kidCount}명`}
+          </span>
+        </div>
+        <div className="w-full flex justify-between items-center">
+          <span className="title text-grey4">이용 시간</span>
+          <span className="body4 text-grey6">
+            {eventStartTime} ~ {eventEndTime}
+          </span>
+        </div>
+        <div className="w-full border-b-[1px] border-grey4" />
+        <div className="w-full h-fit flex justify-between gap-x-[126px]">
+          <span className="title4 text-grey6">총 결제 금액</span>
+          <div className="w-fit h-fit flex flex-col items-end gap-y-[6px]">
+            <span className="headline2 text-status_red1">
+              {stageFirstPrice}
+              <span className="title3 text-status_red1">원</span>
+            </span>
+            <span className="caption4 text-grey3">세금 및 수수료 포함</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/payment/before/BeforeSecondStageCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageCard.tsx
@@ -1,0 +1,142 @@
+interface BeforeSecondStageCardProps {
+  userName: string;
+  phoneNumber: string | null;
+  couponDiscountPrice: number;
+  defaultPrice: number; // 기존의 예약 금액을 의미함
+}
+
+interface BeforeSecondStageUserInfoCardProps {
+  userName: string;
+  phoneNumber: string | null;
+}
+
+interface BeforeSecondStageCouponCardProps {
+  isDiscountCouponAvailable: boolean; // 사용 가능한 쿠폰이 남아 있는지를 조회하는 속성
+  couponDiscountPrice: number;
+}
+
+interface BeforeSecondStageFinalPriceCardProps {
+  couponDiscountPrice: number;
+  defaultPrice: number;
+}
+
+export default function BeforeSecondStageCard({
+  userName,
+  phoneNumber,
+  couponDiscountPrice,
+  defaultPrice,
+}: BeforeSecondStageCardProps) {
+  return (
+    <section className="w-eightNineWidth h-fit  flex flex-col gap-y-[10px] mt-[30px] mb-[30px]">
+      <BeforeSecondStageUserInfoCard
+        userName={userName}
+        phoneNumber={phoneNumber}
+      />
+      <BeforeSecondStageCouponCard
+        isDiscountCouponAvailable={true}
+        couponDiscountPrice={0}
+      />
+      <BeforeSecondStageFinalPriceCard
+        couponDiscountPrice={couponDiscountPrice}
+        defaultPrice={defaultPrice}
+      />
+    </section>
+  );
+}
+
+function BeforeSecondStageUserInfoCard({
+  userName,
+  phoneNumber,
+}: BeforeSecondStageUserInfoCardProps) {
+  return (
+    <div className="w-full h-fit rounded-[10px] flex flex-col items-center gap-y-5 bg-white py-5">
+      <div className="w-sevenEightWidth h-fit flex flex-col gap-y-5">
+        <span className="title3 text-grey7">예약 고객</span>
+        <div className="w-full border-b-[1px] border-grey2" />
+      </div>
+      <div className="w-sevenEightWidth flex justify-between items-center gap-x-[43px]">
+        <span className="title4 w-[21px] text-grey6">이름</span>
+        <input
+          type="text"
+          value={userName}
+          className="w-[80%] border-b-[1px] border-grey3"
+        />
+      </div>
+      <div className="w-sevenEightWidth flex justify-between items-center gap-x-6">
+        <span className="w-[40px] flex gap-x-[1px] items-center title4 text-grey6 ">
+          {'연락처'}
+          <div className="h-full title4 text-status_red1">*</div>
+        </span>
+        <input
+          type="text"
+          // value={userName}
+          placeholder="휴대폰 번호 입력"
+          className="placeholder:body4 placeholder:text-grey3 w-[80%] border-b-[1px] border-grey3"
+        />
+      </div>
+    </div>
+  );
+}
+
+function BeforeSecondStageCouponCard({
+  isDiscountCouponAvailable,
+  couponDiscountPrice,
+}: BeforeSecondStageCouponCardProps) {
+  return (
+    <div className="w-full h-fit rounded-[10px] flex flex-col items-center py-5 gap-y-5 bg-white">
+      <div className="w-sevenEightWidth title3 text-grey7">쿠폰 할인</div>
+      <div className="w-sevenEightWidth border-b-[1px] border-grey2" />
+      <div className="w-sevenEightWidth flex justify-between items-center">
+        <div className="w-fit h-full flex justify-between items-center gap-x-5">
+          <span className="title4 text-grey6">일반 쿠폰</span>
+          {!isDiscountCouponAvailable && (
+            <span className="body4 text-grey3">
+              적용 가능한 쿠폰이 없습니다.
+            </span>
+          )}
+          {isDiscountCouponAvailable && (
+            <button className="px-[10px] w-fit h-full py-1 bg-black text-white title4 rounded-[6px]">
+              사용하기
+            </button>
+          )}
+        </div>
+        <span className="body4 text-grey6">-{couponDiscountPrice}원</span>
+      </div>
+    </div>
+  );
+}
+
+function BeforeSecondStageFinalPriceCard({
+  couponDiscountPrice,
+  defaultPrice,
+}: BeforeSecondStageFinalPriceCardProps) {
+  return (
+    <div className="w-full h-fit rounded-[10px] flex flex-col py-5 items-center gap-y-5 bg-white shadow-myPageLogoutButton">
+      <div className="w-sevenEightWidth h-fit flex justify-start items-center title3 text-grey7">
+        최종 결제 금액
+      </div>
+      <div className="w-sevenEightWidth border-b-[1px] border-grey2" />
+      <div className="w-sevenEightWidth flex justify-between items-center">
+        <span className="title4 text-grey4">예약 금액</span>
+        <span className="body4 text-grey6">{defaultPrice}원</span>
+      </div>
+      <div className="w-sevenEightWidth flex justify-between items-center">
+        <span className="title4 text-grey4">쿠폰 할인 금액</span>
+        <span className="body4 text-grey6">-{couponDiscountPrice}원</span>
+      </div>
+      <div className="w-sevenEightWidth border-b-[1px] border-grey4s" />
+      <div className="w-sevenEightWidth h-fit flex flex-col gap-y-[6px]">
+        <div className="w-full flex justify-between items-center">
+          <span className="title4 text-grey6">총 결제 금액</span>
+          <div className=" flex items-center headline2 text-status_red1">
+            {defaultPrice - couponDiscountPrice}
+            <span className="title3 text-status_red1">원</span>
+          </div>
+        </div>
+        <div className="w-full flex justify-end items-center caption4 text-grey3">
+          세금 및 수수료 포함
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/payment/before/ReservationStageBar.tsx
+++ b/src/components/payment/before/ReservationStageBar.tsx
@@ -1,0 +1,52 @@
+'use client';
+import useReservationStage from '@store/reservationStageStore';
+import { cn } from '@utils/cn';
+
+interface ReservationStageBarItemProps {
+  stageNumber: number;
+  title: string;
+}
+
+function ReservationStageBarItem({
+  stageNumber,
+  title,
+}: ReservationStageBarItemProps) {
+  const reservationStageState = useReservationStage(
+    (state) => state.reservationStage
+  );
+  return (
+    <div className="w-[44px] h-fit flex flex-col items-center gap-y-2">
+      <p
+        className={cn(
+          'w-6 h-6  flex justify-center items-center title4 text-white  rounded-[50%] relative',
+          {
+            'bg-grey6': stageNumber === reservationStageState,
+            'bg-grey3': stageNumber !== reservationStageState,
+            'reservation-stage-item': stageNumber === 1 || stageNumber == 2,
+          }
+        )}
+      >
+        {stageNumber}
+      </p>
+      <span
+        className={cn('title4', {
+          'text-grey6': stageNumber === reservationStageState,
+          'text-grey3': stageNumber !== reservationStageState,
+        })}
+      >
+        {title}
+      </span>
+    </div>
+  );
+}
+
+export default function ReservationStageBar() {
+  return (
+    <div className="w-full h-fit pt-[78px] flex justify-center items-center gap-x-5">
+      <ReservationStageBarItem stageNumber={1} title="예약 확인" />
+      <ReservationStageBarItem stageNumber={2} title="예약 결제" />
+      <ReservationStageBarItem stageNumber={3} title="예약 확정" />
+      <div />
+    </div>
+  );
+}

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -17,7 +17,6 @@ export default function HistoryEndItem({
   reservationId,
   reviewId,
 }: HistoryEndItemProps) {
-  console.log(reviewId);
   return (
     <Link
       href={`/reservation-list/reservation/${reservationId}`}

--- a/src/store/reservationStageStore.ts
+++ b/src/store/reservationStageStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface Store {
+  reservationStage: 1 | 2 | 3;
+  setReservationStage: (status: 1 | 2 | 3) => void;
+}
+
+const useReservationStage = create<Store>((set) => ({
+  reservationStage: 1,
+  setReservationStage(status) {
+    set({ reservationStage: status });
+  },
+}));
+
+export default useReservationStage;


### PR DESCRIPTION
## 🕹️ 개요
`/payment/before` 페이지 작업

## 🔎 작업 사항
1. 1단계와 2단계에 해당하는 컴포넌트를 만듬
2. 2단계에서 버튼을 누르는 순간 그때 결제 api로 연동하고 원하는 페이지로 사용자를 던지면 될듯(추후 작업 예상)
3. reservation 단계는 zustand 전역 상태를 통해서 관리

## 📋 작업 브랜치
