### PR TITLE
Feat/result to detail

### DIFF
--- a/src/app/search/result/SearchResult.tsx
+++ b/src/app/search/result/SearchResult.tsx
@@ -12,6 +12,7 @@ import { ResultCardProps } from 'types/search/result/searchResult';
 const DUMMYRESULTS: ResultCardProps[] = [
   {
     clubName: '스카이락볼링장1',
+    clubId: 1,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -22,6 +23,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장2',
+    clubId: 2,
     location:
       '서울특별시 강남구 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동',
     rating: 4.5,
@@ -33,6 +35,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장3',
+    clubId: 3,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -43,6 +46,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장4',
+    clubId: 4,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -53,6 +57,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장5',
+    clubId: 5,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -62,6 +67,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장6',
+    clubId: 6,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -73,6 +79,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장7',
+    clubId: 7,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -84,6 +91,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장8',
+    clubId: 8,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -95,6 +103,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장9',
+    clubId: 9,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -106,6 +115,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장10',
+    clubId: 10,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -9,6 +9,7 @@ import { da } from 'date-fns/locale';
 const DUMMYRESULTS: ResultCardProps[] = [
   {
     clubName: '스카이락볼링장1',
+    clubId: 1,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -19,6 +20,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장2',
+    clubId: 2,
     location:
       '서울특별시 강남구 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동',
     rating: 4.5,
@@ -30,6 +32,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장3',
+    clubId: 3,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -40,6 +43,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장4',
+    clubId: 4,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -50,6 +54,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장5',
+    clubId: 5,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -59,6 +64,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장6',
+    clubId: 6,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -70,6 +76,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장7',
+    clubId: 7,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -81,6 +88,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장8',
+    clubId: 8,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -92,6 +100,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장9',
+    clubId: 9,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,
@@ -103,6 +112,7 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
   {
     clubName: '스카이락볼링장10',
+    clubId: 10,
     location: '서울특별시 강남구 역삼동',
     rating: 4.5,
     reviewCount: 100,

--- a/src/components/reservation/ResReservationCard.tsx
+++ b/src/components/reservation/ResReservationCard.tsx
@@ -2,7 +2,7 @@
 import InfoCard from '@components/search/InfoCard';
 import { useSearchParams } from 'next/navigation';
 import DateSVG from '@public/svg/date.svg';
-import ResTimeSVG from '@public/svg/restime.svg';
+import ResTimeSVG from '@public/svg/resTime.svg';
 import PeopleSVG from '@public/svg/people.svg';
 
 interface ResReservationCardProps {

--- a/src/components/search/result/BottomSheet.tsx
+++ b/src/components/search/result/BottomSheet.tsx
@@ -40,9 +40,11 @@ export default function BottomSheet({ results }: BottomSheetProps) {
           className="overflow-y-scroll z-10 h-full w-full relative !grow-0"
           disableDrag={true}
         >
-          {results.map((result) => (
-            <ResultCard key={result.clubName} {...result} />
-          ))}
+          {results.map((result, idx) => {
+            if (idx === results.length - 1)
+              return <ResultCard key={result.clubName} {...result} isLast />;
+            return <ResultCard key={result.clubName} {...result} />;
+          })}
         </Sheet.Content>
       </Sheet.Container>
     </Sheet>

--- a/src/components/search/result/NaverMap.tsx
+++ b/src/components/search/result/NaverMap.tsx
@@ -1,17 +1,21 @@
 'use client';
 import { info } from 'console';
 import Script from 'next/script';
+import { useEffect, useRef } from 'react';
 
 export default function NaverMap() {
+  const mapRef = useRef<naver.maps.Map | null>(null);
+
   const initializeMap = () => {
     const mapOptions = {
       center: new naver.maps.LatLng(37.3595704, 127.105399),
       zoom: 15,
       logoControl: false,
       mapDataControl: false,
-      scaleControl: false
+      scaleControl: false,
     };
     const map = new naver.maps.Map('map', mapOptions);
+    mapRef.current = map;
     const markers: naver.maps.Marker[] = [];
     const infoWindows: naver.maps.InfoWindow[] = [];
     for (let i = 1; i < 100; i++) {
@@ -55,12 +59,15 @@ export default function NaverMap() {
       updateMarkers(map, markers);
     });
 
-    const updateMarkers = (map: naver.maps.Map, markers: naver.maps.Marker[]) => {
-      const mapBounds : any = map.getBounds();
-    
+    const updateMarkers = (
+      map: naver.maps.Map,
+      markers: naver.maps.Marker[]
+    ) => {
+      const mapBounds: any = map.getBounds();
+
       for (let i = 0; i < markers.length; i++) {
         const position = markers[i].getPosition();
-    
+
         if (mapBounds.hasLatLng(position)) {
           showMarker(map, markers[i]);
         } else {
@@ -77,25 +84,31 @@ export default function NaverMap() {
     const hideMarker = (map: naver.maps.Map, marker: naver.maps.Marker) => {
       marker.setMap(null);
     };
-    
-  //   function getClickHandler(seq:number) {
-  //     return function() {
-  //         var marker = markers[seq],
-  //             infoWindow = infoWindows[seq];
-  
-  //         if (infoWindow.getMap()) {
-  //             infoWindow.close();
-  //         } else {
-  //             infoWindow.open(map, marker);
-  //         }
-  //     }
-  // }
-  
-  // for (var i=0, ii=markers.length; i<ii; i++) {
-  //     naver.maps.Event.addListener(markers[i], 'click', getClickHandler(i));
-  // }
 
+    //   function getClickHandler(seq:number) {
+    //     return function() {
+    //         var marker = markers[seq],
+    //             infoWindow = infoWindows[seq];
+
+    //         if (infoWindow.getMap()) {
+    //             infoWindow.close();
+    //         } else {
+    //             infoWindow.open(map, marker);
+    //         }
+    //     }
+    // }
+
+    // for (var i=0, ii=markers.length; i<ii; i++) {
+    //     naver.maps.Event.addListener(markers[i], 'click', getClickHandler(i));
+    // }
   };
+
+  useEffect(() => {
+    return () => {
+      mapRef.current?.destroy();
+    };
+  }, []);
+
   return (
     <section className="w-full h-full">
       <Script

--- a/src/components/search/result/ResultCard.tsx
+++ b/src/components/search/result/ResultCard.tsx
@@ -5,9 +5,12 @@ import StarSVG from '@public/svg/star.svg';
 import EmptyHeartSVG from '@public/svg/emptyHeart.svg';
 import FillHeartSVG from '@public/svg/fillHeart.svg';
 import DiscountSVG from '@public/svg/discount.svg';
+import Link from 'next/link';
+import { cn } from '@utils/cn';
 
 export default function ResultCard({
   clubName,
+  clubId,
   location,
   rating,
   reviewCount,
@@ -16,16 +19,17 @@ export default function ResultCard({
   isEvent = false,
   isHeart = false,
   image,
+  isLast = false,
 }: ResultCardProps) {
   return (
-    <article className="w-full h-[168px] flex gap-4 p-5 border-b border-grey2 max-w-[480px] min-w-[360px]">
+    <Link
+      href={`/detail-page/${clubId}`}
+      className={cn("w-full h-[168px] flex gap-4 p-5 border-b border-grey2 max-w-[480px] min-w-[360px]",{
+        'pb-[60px] h-fit': isLast
+      })}
+    >
       <div className="relative shrink-0">
-        <Image
-          src={image}
-          alt={clubName}
-          width={128}
-          height={128}
-        />
+        <Image src={image} alt={clubName} width={128} height={128} />
         {isEvent && <DiscountSVG className="absolute top-2 left-2" />}
         {isHeart ? (
           <FillHeartSVG className="absolute bottom-2 right-2" />
@@ -38,7 +42,9 @@ export default function ResultCard({
           <div className="w-full flex flex-col gap-1">
             <p className="title3 text-grey7">{clubName}</p>
             {/* max-w 조금 더 최적화 필요할 듯 */}
-            <p className="body4 text-grey5 truncate max-w-[180px]">{location}</p>
+            <p className="body4 text-grey5 truncate max-w-[180px]">
+              {location}
+            </p>
           </div>
           <div className="flex gap-[6px] h-[25px]">
             <p className="bg-primary_orange2 text-primary_orange1 title4 gap-[2px] w-[44px] h-[25px] flex justify-center items-center">
@@ -53,6 +59,6 @@ export default function ResultCard({
           <p className="body4 grey4">{gameType}당 가격</p>
         </div>
       </div>
-    </article>
+    </Link>
   );
 }

--- a/src/types/search/result/searchResult.ts
+++ b/src/types/search/result/searchResult.ts
@@ -1,5 +1,6 @@
 export interface ResultCardProps {
   clubName: string;
+  clubId: number;
   location: string;
   rating: number;
   reviewCount: number;
@@ -8,4 +9,5 @@ export interface ResultCardProps {
   isEvent?: boolean;
   isHeart?: boolean;
   image: string;
+  isLast?: boolean;
 }


### PR DESCRIPTION
## 🕹️ 개요
필요한 부분 리팩토링

## 🔎 작업 사항
- ResTimeSVG의 경로 정상적으로 변경
- 지도 unMount 될때 destroy되는 코드 추가. onLoad Props는 따로 없고 <Script />내에 정의되어 있어서 따로 정의하지 않음
- 바텀시트 마지막 컴포넌트 패딩 추가
- ResultCard 클릭 시 상세페이지로 이동. wishList 페이지에서도 정상적으로 동작

## 📋 작업 브랜치
Feat/resultToDetail