### PR TITLE
Feat/coupon apply : 쿠폰 기능 적용 및 휴대폰 번호 입력 안하고 결제 하려고 할 때 모달창 구현

### DIFF
--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -6,25 +6,12 @@ import BeforeSecondStageCard from '@components/payment/before/BeforeSecondStageC
 import FullButton from '@components/all/FullButton';
 import useReservationStage from '@store/reservationStageStore';
 import CouponPage from '@components/payment/before/CouponPage';
-import { useState } from 'react';
+import { useEffect } from 'react';
 import { useIsCouponPageOpen } from '@store/couponStore';
-
-const DUMMYFIRSTSTAGEDATA = {
-  companyName: '스카이락 볼링장',
-  companyAddress: '서울 서대문구 신촌로 73 케이스퀘어 8층',
-  eventDate: '05.17 (금)',
-  adultCount: 2,
-  eventStartTime: '오전 10:00',
-  eventEndTime: '오전 11:00',
-  stageFirstPrice: 22000,
-};
-
-const DUMMYSECONDSTAGEDATA = {
-  userName: '김티그',
-  phoneNumber: null,
-  couponDiscountPrice: 0,
-  defaultPrice: 22000,
-};
+import {
+  usePaymentFirstStage,
+  usePaymentSecondStage,
+} from '@store/paymentInfoStore';
 
 export default function Page() {
   const reservationStageState = useReservationStage(
@@ -33,6 +20,47 @@ export default function Page() {
   const isCouponPageOpen = useIsCouponPageOpen(
     (state) => state.isCouponPageOpen
   );
+
+  const firstStageInfoObject = usePaymentFirstStage(
+    (state) => state.firstStageInfoObject
+  );
+
+  const setFirstStageInfoObject = usePaymentFirstStage(
+    (state) => state.setFirstStageInfoObject
+  );
+
+  const secondStageInfoObject = usePaymentSecondStage(
+    (state) => state.secondStageInfoObject
+  );
+
+  const setSecondStageInfoObject = usePaymentSecondStage(
+    (state) => state.setSecondStageInfoObject
+  );
+
+  useEffect(() => {
+    // 실제로는 현재 페이지 컴포넌트가 로드될 때, 날짜, 성인수, 청소년수, 어린이수, 시작 시간, 종료시간, 가격을 백엔드로부터 받아서 상태 값을 설정해준다.
+    // 일단 임시 데이터를 통해 화면 UI 완성
+    const DUMMYFIRSTSTAGEDATA = {
+      companyName: '스카이락 볼링장',
+      companyAddress: '서울 서대문구 신촌로 73 케이스퀘어 8층',
+      eventDate: '05.17 (금)',
+      adultCount: 2,
+      eventStartTime: '오전 10:00',
+      eventEndTime: '오전 11:00',
+      stageFirstPrice: 22000,
+    };
+
+    setFirstStageInfoObject(DUMMYFIRSTSTAGEDATA);
+
+    const DUMMYSECONDSTAGEDATA = {
+      userName: '김티그',
+      phoneNumber: '',
+      couponDiscountPrice: 0,
+      defaultPrice: 22000,
+    };
+
+    setSecondStageInfoObject(DUMMYSECONDSTAGEDATA);
+  }, []);
 
   return !isCouponPageOpen ? (
     <main className="w-full h-full flex flex-col items-center bg-grey1 pb-[100px] overflow-y-scroll">
@@ -45,11 +73,11 @@ export default function Page() {
       />
       <ReservationStageBar />
       {reservationStageState === 1 && (
-        <BeforeFirstStageCard {...DUMMYFIRSTSTAGEDATA} />
+        <BeforeFirstStageCard {...firstStageInfoObject} />
       )}
 
       {reservationStageState === 2 && (
-        <BeforeSecondStageCard {...DUMMYSECONDSTAGEDATA} />
+        <BeforeSecondStageCard {...secondStageInfoObject} />
       )}
 
       {reservationStageState === 1 && (

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -12,6 +12,8 @@ import {
   usePaymentFirstStage,
   usePaymentSecondStage,
 } from '@store/paymentInfoStore';
+import Modal from '@components/all/Modal';
+import useModal from '@store/modalStore';
 
 export default function Page() {
   const reservationStageState = useReservationStage(
@@ -35,6 +37,10 @@ export default function Page() {
 
   const setSecondStageInfoObject = usePaymentSecondStage(
     (state) => state.setSecondStageInfoObject
+  );
+
+  const setSelectedIsModalOpen = useModal(
+    (state) => state.setSelectedIsModalOpen
   );
 
   useEffect(() => {
@@ -98,8 +104,15 @@ export default function Page() {
           bgColor="primary_orange1"
           content="확인"
           className="absolute !w-eightNineWidth bottom-[30px]"
+          clickTask="request-payment"
         />
       )}
+      <Modal
+        size="sm"
+        button2Content="확인"
+        title="휴대폰 번호를 입력해주세요"
+        secondButtonFunc={() => setSelectedIsModalOpen(false)}
+      />
     </main>
   ) : (
     <CouponPage />

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -2,8 +2,12 @@
 import { cn } from '@utils/cn';
 import { useRouter } from 'next/navigation';
 import useReservationStage from '@store/reservationStageStore';
-import { usePaymentSecondStage } from '@store/paymentInfoStore';
+import {
+  usePaymentFirstStage,
+  usePaymentSecondStage,
+} from '@store/paymentInfoStore';
 import { useIsCouponPageOpen } from '@store/couponStore';
+import useModal from '@store/modalStore';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -30,7 +34,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | 'move-to-written-review-page'
     | 'move-to-home-page'
     | 'move-to-second-payment-stage'
-    | 'apply-coupon';
+    | 'apply-coupon'
+    | 'request-payment';
   sendingData?: {
     reviewId?: number;
     reservationId?: number;
@@ -52,6 +57,11 @@ export default function FullButton({
   const setReservationStageStatus = useReservationStage(
     (state) => state.setReservationStage
   );
+
+  const firstStageInfoObject = usePaymentFirstStage(
+    (state) => state.firstStageInfoObject
+  );
+
   const secondStageInfoObject = usePaymentSecondStage(
     (state) => state.secondStageInfoObject
   );
@@ -62,6 +72,10 @@ export default function FullButton({
 
   const setIsCouponPageOpen = useIsCouponPageOpen(
     (state) => state.setIsCouponPageOpen
+  );
+
+  const setSelectedIsModalOpen = useModal(
+    (state) => state.setSelectedIsModalOpen
   );
 
   const colorClasses = {
@@ -113,6 +127,12 @@ export default function FullButton({
       });
       setIsCouponPageOpen(false);
       return;
+    }
+
+    if (clickTask === 'request-payment') {
+      if (secondStageInfoObject.phoneNumber === '') {
+        setSelectedIsModalOpen(true);
+      }
     }
   }
 

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -2,6 +2,8 @@
 import { cn } from '@utils/cn';
 import { useRouter } from 'next/navigation';
 import useReservationStage from '@store/reservationStageStore';
+import { usePaymentSecondStage } from '@store/paymentInfoStore';
+import { useIsCouponPageOpen } from '@store/couponStore';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -27,10 +29,12 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | 'move-to-writing-review-page'
     | 'move-to-written-review-page'
     | 'move-to-home-page'
-    | 'move-to-second-payment-stage';
+    | 'move-to-second-payment-stage'
+    | 'apply-coupon';
   sendingData?: {
     reviewId?: number;
     reservationId?: number;
+    selectedCouponPrice?: number;
   };
 }
 
@@ -48,6 +52,18 @@ export default function FullButton({
   const setReservationStageStatus = useReservationStage(
     (state) => state.setReservationStage
   );
+  const secondStageInfoObject = usePaymentSecondStage(
+    (state) => state.secondStageInfoObject
+  );
+
+  const setSecondStageInfoObject = usePaymentSecondStage(
+    (state) => state.setSecondStageInfoObject
+  );
+
+  const setIsCouponPageOpen = useIsCouponPageOpen(
+    (state) => state.setIsCouponPageOpen
+  );
+
   const colorClasses = {
     status_red1: 'text-status_red1',
     primary_orange1: 'text-primary_orange1',
@@ -72,18 +88,31 @@ export default function FullButton({
       ev.stopPropagation();
       ev.preventDefault();
       router.push(`/writing-review/${sendingData?.reservationId}`);
+      return;
     }
 
     if (clickTask === 'move-to-written-review-page') {
       ev.stopPropagation();
       ev.preventDefault();
       router.push(`/reservation-list/review/${sendingData?.reviewId}`);
+      return;
     }
     if (clickTask === 'move-to-home-page') {
       router.push('/');
+      return;
     }
     if (clickTask === 'move-to-second-payment-stage') {
       setReservationStageStatus(2);
+      return;
+    }
+
+    if (clickTask === 'apply-coupon') {
+      setSecondStageInfoObject({
+        ...secondStageInfoObject,
+        couponDiscountPrice: sendingData?.selectedCouponPrice as number,
+      });
+      setIsCouponPageOpen(false);
+      return;
     }
   }
 

--- a/src/components/all/Modal.tsx
+++ b/src/components/all/Modal.tsx
@@ -5,7 +5,7 @@ import FullButton from './FullButton';
 
 interface ModalProps {
   size: 'sm' | 'lg';
-  button1Content: string;
+  button1Content?: string;
   button2Content?: string;
   title: string;
   subTitle?: string;

--- a/src/components/payment/before/BeforeSecondStageCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageCard.tsx
@@ -22,7 +22,7 @@ export default function BeforeSecondStageCard({
         userName={userName}
         phoneNumber={phoneNumber}
       />
-      <BeforeSecondStageCouponCard couponDiscountPrice={0} />
+      <BeforeSecondStageCouponCard couponDiscountPrice={couponDiscountPrice} />
       <BeforeSecondStageFinalPriceCard
         couponDiscountPrice={couponDiscountPrice}
         defaultPrice={defaultPrice}

--- a/src/components/payment/before/BeforeSecondStageCouponCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageCouponCard.tsx
@@ -10,7 +10,7 @@ export default function BeforeSecondStageCouponCard({
   couponDiscountPrice,
 }: BeforeSecondStageCouponCardProps) {
   const [isDiscountCouponAvailable, setIsDiscountCouponAvailable] =
-    useState<boolean>(false);
+    useState<boolean>(true);
 
   const setIsCouponPageOpen = useIsCouponPageOpen(
     (state) => state.setIsCouponPageOpen

--- a/src/components/payment/before/CouponPage.tsx
+++ b/src/components/payment/before/CouponPage.tsx
@@ -22,7 +22,7 @@ interface couponItemDetail extends couponDetail {
 export default function CouponPage() {
   const couponList = useCoupon((state) => state.couponList);
   const setCouponList = useCoupon((state) => state.setCouponList);
-  const [selectedCouponNumber, setselectedCouponNumber] = useState<number>(0);
+  const [selectedCouponNumber, setselectedCouponNumber] = useState<number>(-1);
 
   useEffect(() => {
     // 원래는 백엔드로부터 쿠폰 리스트들을 받아오는 로직이 존재
@@ -84,11 +84,11 @@ export default function CouponPage() {
             couponExpireDate={coupon.couponExpireDate}
             selectedCouponNumber={selectedCouponNumber}
             handleClickCoupon={setselectedCouponNumber}
-            couponIndex={index + 1}
+            couponIndex={index}
           />
         ))}
       </div>
-      {selectedCouponNumber === 0 ? (
+      {selectedCouponNumber === -1 ? (
         <FullButton
           size="lg"
           color="white"
@@ -103,6 +103,11 @@ export default function CouponPage() {
           bgColor="primary_orange1"
           content="적용하기"
           className="absolute bottom-[30px] !w-eightNineWidth"
+          clickTask="apply-coupon"
+          sendingData={{
+            selectedCouponPrice: couponList[selectedCouponNumber].discountPrice,
+            // 추후에는 필요에 따라 쿠폰의 가격 뿐만 아니라 id까지 적용시킬 수도 있음
+          }}
         />
       )}
     </main>
@@ -150,7 +155,7 @@ function CouponItem({
         {selectedCouponNumber === couponIndex ? (
           <div
             className="w-7 h-7 flex justify-center items-center rounded-[50%] bg-primary_orange1 hover:cursor-pointer"
-            onClick={() => handleClickCoupon(0)}
+            onClick={() => handleClickCoupon(-1)}
           >
             <ChevronDownSVG />
           </div>

--- a/src/store/couponStore.ts
+++ b/src/store/couponStore.ts
@@ -14,7 +14,7 @@ interface Store {
 
 const useCoupon = create<Store>((set) => ({
   couponList: [],
-  setCouponList: (staus) => set({ couponList: staus }),
+  setCouponList: (status) => set({ couponList: status }),
 }));
 
 export default useCoupon;

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+
+interface paymentFirstStageInfoProps {
+  companyName: string;
+  companyAddress: string;
+  eventDate: string;
+  adultCount: number;
+  youngManCount?: number;
+  kidCount?: number;
+  eventStartTime: string;
+  eventEndTime: string;
+  stageFirstPrice: number;
+}
+
+interface paymentFirstStageStore {
+  firstStageInfoObject: paymentFirstStageInfoProps;
+  setFirstStageInfoObject: (status: paymentFirstStageInfoProps) => void;
+}
+
+// first stage에서의 정보를 관리
+export const usePaymentFirstStage = create<paymentFirstStageStore>((set) => ({
+  firstStageInfoObject: {
+    companyName: '',
+    companyAddress: '',
+    eventDate: '',
+    adultCount: 0,
+    youngManCount: 0,
+    kidCount: 0,
+    eventStartTime: '',
+    eventEndTime: '',
+    stageFirstPrice: 0,
+  },
+  setFirstStageInfoObject: (status: paymentFirstStageInfoProps) =>
+    set({ firstStageInfoObject: status }),
+}));
+
+interface paymentSecondStageInfoProps {
+  userName: string;
+  phoneNumber: string;
+  couponDiscountPrice: number;
+  defaultPrice: number;
+}
+
+interface paymentSecondStageStore {
+  secondStageInfoObject: paymentSecondStageInfoProps;
+  setSecondStageInfoObject: (status: paymentSecondStageInfoProps) => void;
+}
+
+// second stage에서의 정보를 관리
+export const usePaymentSecondStage = create<paymentSecondStageStore>((set) => ({
+  secondStageInfoObject: {
+    userName: '',
+    phoneNumber: '',
+    couponDiscountPrice: 0,
+    defaultPrice: 0,
+  },
+  setSecondStageInfoObject: (status: paymentSecondStageInfoProps) =>
+    set({ secondStageInfoObject: status }),
+}));


### PR DESCRIPTION
## 🔎 작업 사항
1. 크게 paymentFirststage와 payment second stage에 대한 전역상태를 paymentInfostore.ts에 구분하여 정리했음. 이를 필요할 때마다 커스텀 훅을 import 하여 사용했음
2. 휴대폰 번호 입력 없을 때 뜨는 모달만 생긴게 달라서, `Modal` 컴포넌트의 Button1Content도 optional로 일단 만들어주고 Button2Content만 사용하는 방식으로 진행했음.
3. 우리가 Modal을 사용하는 페이지들 나중에 언마운트할 때 useEffect() 훅의 cleaning 함수로 modal 상태 다 지워주는 작업은 추후에 ㄱ ㄱ하자

## 📋 작업 브랜치
