### PR TITLE
Feat/payment : /payment/before와 /payment/after 페이지 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
+        "react-hot-toast": "^2.4.1",
         "react-modal": "^3.16.1",
         "react-modal-sheet": "^3.1.0",
         "recoil": "^0.7.7",
@@ -5310,6 +5311,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6830,6 +6839,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-hot-toast": "^2.4.1",
     "react-modal": "^3.16.1",
     "react-modal-sheet": "^3.1.0",
     "recoil": "^0.7.7",

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,6 +3,7 @@ import NavBar from '@components/all/NavBar/NavBar';
 import My from '@components/mypage/My';
 import NoneArrowHeader from '@components/all/NoneArrowHeader';
 import Modal from '@components/all/Modal';
+import { Toaster } from 'react-hot-toast';
 
 export default function page() {
   return (
@@ -14,9 +15,10 @@ export default function page() {
         button1Content="이전으로"
         button2Content="로그아웃"
         title="로그아웃 하시겠습니까?"
-        // 추후에 로그아웃 함수 부착
       />
+
       <NavBar />
+      <Toaster position="bottom-center" containerStyle={{ bottom: '75px' }} />
     </div>
   );
 }

--- a/src/app/payment/after/[reservationId]/page.tsx
+++ b/src/app/payment/after/[reservationId]/page.tsx
@@ -1,9 +1,20 @@
 import Header from '@components/all/Header';
+import PaymentAfterConfirm from '@components/payment/after/PaymentAfterConfirm';
+import FullButton from '@components/all/FullButton';
 
 export default function page() {
   return (
-    <div>
+    <main className="w-full h-full flex flex-col items-center bg-grey1 pb-[100px] overflow-y-scroll">
       <Header buttonType="close" isCenter title="예약 결제" bgColor="grey" />
-    </div>
+      <PaymentAfterConfirm />
+      <FullButton
+        size="lg"
+        color="white"
+        bgColor="primary_orange1"
+        content="확인"
+        className="!w-eightNineWidth absolute bottom-[30px]"
+        clickTask="move-to-home-page"
+      />
+    </main>
   );
 }

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -11,9 +11,12 @@ import { useIsCouponPageOpen } from '@store/couponStore';
 import {
   usePaymentFirstStage,
   usePaymentSecondStage,
+  paymentSecondStageInfoProps,
+  paymentFirstStageInfoProps,
 } from '@store/paymentInfoStore';
 import Modal from '@components/all/Modal';
 import useModal from '@store/modalStore';
+import { Toaster } from 'react-hot-toast';
 
 export default function Page() {
   const reservationStageState = useReservationStage(
@@ -46,7 +49,7 @@ export default function Page() {
   useEffect(() => {
     // 실제로는 현재 페이지 컴포넌트가 로드될 때, 날짜, 성인수, 청소년수, 어린이수, 시작 시간, 종료시간, 가격을 백엔드로부터 받아서 상태 값을 설정해준다.
     // 일단 임시 데이터를 통해 화면 UI 완성
-    const DUMMYFIRSTSTAGEDATA = {
+    const DUMMYFIRSTSTAGEDATA: paymentFirstStageInfoProps = {
       companyName: '스카이락 볼링장',
       companyAddress: '서울 서대문구 신촌로 73 케이스퀘어 8층',
       eventDate: '05.17 (금)',
@@ -58,7 +61,7 @@ export default function Page() {
 
     setFirstStageInfoObject(DUMMYFIRSTSTAGEDATA);
 
-    const DUMMYSECONDSTAGEDATA = {
+    const DUMMYSECONDSTAGEDATA: paymentSecondStageInfoProps = {
       userName: '김티그',
       phoneNumber: '',
       couponDiscountPrice: 0,
@@ -113,6 +116,7 @@ export default function Page() {
         title="휴대폰 번호를 입력해주세요"
         secondButtonFunc={() => setSelectedIsModalOpen(false)}
       />
+      <Toaster position="bottom-center" containerStyle={{ bottom: '90px' }} />
     </main>
   ) : (
     <CouponPage />

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -8,6 +8,10 @@ import {
 } from '@store/paymentInfoStore';
 import { useIsCouponPageOpen } from '@store/couponStore';
 import useModal from '@store/modalStore';
+import { isValidPhoneNumber } from '@utils/validationCheck';
+import toast from 'react-hot-toast';
+import ToastUI, { toastUIDuration } from '@components/mypage/ToastUI';
+import { useState } from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -78,6 +82,8 @@ export default function FullButton({
     (state) => state.setSelectedIsModalOpen
   );
 
+  const [toastId, setToastId] = useState<string | null>(null);
+
   const colorClasses = {
     status_red1: 'text-status_red1',
     primary_orange1: 'text-primary_orange1',
@@ -132,7 +138,24 @@ export default function FullButton({
     if (clickTask === 'request-payment') {
       if (secondStageInfoObject.phoneNumber === '') {
         setSelectedIsModalOpen(true);
+        return;
       }
+      if (!isValidPhoneNumber(secondStageInfoObject.phoneNumber)) {
+        if (toastId !== null) {
+          toast.remove(toastId);
+        }
+        const id = toast.custom(
+          <ToastUI message="올바른 전화 번호가 아닙니다." />,
+          {
+            duration: toastUIDuration,
+          }
+        );
+
+        setToastId(id);
+        return;
+      }
+      console.log(firstStageInfoObject);
+      console.log(secondStageInfoObject);
     }
   }
 

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -118,7 +118,7 @@ export default function FullButton({
       return;
     }
     if (clickTask === 'move-to-home-page') {
-      router.push('/');
+      router.replace('/');
       return;
     }
     if (clickTask === 'move-to-second-payment-stage') {
@@ -154,8 +154,13 @@ export default function FullButton({
         setToastId(id);
         return;
       }
+      // 이제 해당 정보를 백엔드로 전송하면 됨
       console.log(firstStageInfoObject);
       console.log(secondStageInfoObject);
+
+      // 백엔드 전송 로직
+      // 실제로는 companyId를 다음 주소로 넘겨야함
+      router.replace(`/payment/after/${firstStageInfoObject.companyName}`);
     }
   }
 

--- a/src/components/all/Header.tsx
+++ b/src/components/all/Header.tsx
@@ -28,7 +28,9 @@ export default function Header({
 }: HeaderProps) {
   const router = useRouter();
   const setIsOpen = useModal((state) => state.setSelectedIsModalOpen);
-  const setIsSearchModalOpen = useSearchModal((state)=> state.setSelectedIsSearchModalOpen)
+  const setIsSearchModalOpen = useSearchModal(
+    (state) => state.setSelectedIsSearchModalOpen
+  );
   const setIsCouponPageOpen = useIsCouponPageOpen(
     (state) => state.setIsCouponPageOpen
   );
@@ -60,6 +62,10 @@ export default function Header({
           if (title === '쿠폰') {
             setIsCouponPageOpen(false);
             return;
+          }
+
+          if (title === '예약 결제') {
+            router.replace('/');
           }
 
           if (isSearchModal) {

--- a/src/components/mypage/My.tsx
+++ b/src/components/mypage/My.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import MyProfileDefaultImage from '@public/svg/myProfileDefaultImage.svg';
 import ProfileInformation from './ProfileInformation';
 import ToastUI from './ToastUI';
@@ -9,7 +8,7 @@ export default function My() {
   const setIsOpen = useModal((state) => state.setSelectedIsModalOpen);
   return (
     <div className="w-full flex flex-col items-center absolute top-[68px] pt-5">
-      <div className="w-mypageWidth h-fit flex flex-col items-center gap-y-[30px] mb-[30px]">
+      <div className="w-eightNineWidth mypageWidth h-fit flex flex-col items-center gap-y-[30px] mb-[30px]">
         <MyProfileDefaultImage />
         <ProfileInformation />
       </div>
@@ -22,7 +21,6 @@ export default function My() {
           로그아웃
         </button>
       </div>
-      <ToastUI />
     </div>
   );
 }

--- a/src/components/mypage/ProfileInformation.tsx
+++ b/src/components/mypage/ProfileInformation.tsx
@@ -2,52 +2,44 @@ import { ProfileInformationItemProps } from 'types/mypage/MyPageTypes';
 import ProfileInformationItem from './ProfileInformationItem';
 
 export default function ProfileInformation() {
-  const profileData: ProfileInformationItemProps[] = [
-    {
-      wholeGap: 156,
-      labelGap: 63,
-      labelName: '이름',
-      placeholderName: '김티그',
-      placeholderColor: 'grey7',
-      isButtonBorder: true,
-      buttonText: '변경',
-    },
-    {
-      wholeGap: 59,
-      labelGap: 33,
-      labelName: '휴대폰번호',
-      placeholderName: '휴대폰번호를 입력해주세요',
-      placeholderColor: 'grey3',
-      isButtonBorder: false,
-      buttonText: '변경',
-    },
-    {
-      wholeGap: 108,
-      labelGap: 53,
-      labelName: '이메일',
-      placeholderName: 'tig@naver.com',
-      placeholderColor: 'grey7',
-      isButtonBorder: true,
-      buttonText: '변경',
-    },
-  ];
+  // const [profileInfoDataObject, setProfileInfoDataObject] = useState<
+  //   ProfileInformationItemProps[]
+  // >([]);
+
+  // useEffect(() => {
+  //   const DUMMYPROFILEDATA: ProfileInformationItemProps[] = [
+  //     {
+  //       labelName: '이름',
+  //       inputData: '김티그',
+  //     },
+  //     {
+  //       labelName: '휴대폰번호',
+  //       inputData: '',
+  //     },
+  //     {
+  //       labelName: '이메일',
+  //       inputData: 'tig@naver.com',
+  //     },
+  //   ];
+
+  //   setProfileInfoDataObject(DUMMYPROFILEDATA);
+  // }, []);
+
+  // 추후에 해당 데이터는 여기에서 상태로 선언해서, useEffect()로 백엔드로부터 받아온 다음, 다시 아래 Item에게 내려줘야함
+  // 하위 item 요소에 inputData를 의미하는 상태와, 상태를 바꾸는 setter 함수를 내려줘야함
+
   return (
     <div
       id="profile-info-container"
       className="w-full h-fit flex flex-col gap-y-4"
     >
-      {profileData.map((data, index) => (
-        <ProfileInformationItem
-          key={data.labelName}
-          wholeGap={data.wholeGap}
-          labelGap={data.labelGap}
-          labelName={data.labelName}
-          placeholderName={data.placeholderName}
-          placeholderColor={data.placeholderColor}
-          isButtonBorder={data.isButtonBorder}
-          buttonText={data.buttonText}
-        />
-      ))}
+      {/* {profileInfoDataObject.map((data) => (
+        
+      ))} */}
+
+      <ProfileInformationItem labelName="이름" />
+      <ProfileInformationItem labelName="휴대폰번호" />
+      <ProfileInformationItem labelName="이메일" />
     </div>
   );
 }

--- a/src/components/mypage/ProfileInformationItem.tsx
+++ b/src/components/mypage/ProfileInformationItem.tsx
@@ -4,7 +4,7 @@ import { ProfileInformationItemProps } from 'types/mypage/MyPageTypes';
 import { useState, useEffect } from 'react';
 import { isValidEmail, isValidPhoneNumber } from '@utils/validationCheck';
 import toast from 'react-hot-toast';
-import ToastUI from './ToastUI';
+import ToastUI, { toastUIDuration } from './ToastUI';
 
 export default function ProfileInformationItem({
   labelName,

--- a/src/components/mypage/ProfileInformationItem.tsx
+++ b/src/components/mypage/ProfileInformationItem.tsx
@@ -1,52 +1,130 @@
+'use client';
 import { cn } from '@utils/cn';
 import { ProfileInformationItemProps } from 'types/mypage/MyPageTypes';
+import { useState, useEffect } from 'react';
+import { isValidEmail, isValidPhoneNumber } from '@utils/validationCheck';
+import toast from 'react-hot-toast';
+import ToastUI from './ToastUI';
 
 export default function ProfileInformationItem({
-  wholeGap,
-  labelGap,
   labelName,
-  placeholderName,
-  placeholderColor,
-  isButtonBorder,
-  buttonText,
 }: ProfileInformationItemProps) {
+  const [inputBoxEditStage, setInputBoxEditStage] = useState<1 | 2>(1);
+  const [inputData, setInputData] = useState<string>('');
+  const [toastId, setToastId] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 추후에 백엔드로부터 inputData를 받아올 훅임
+    if (labelName === '이름') {
+      setInputData('김티그');
+    } else if (labelName === '휴대폰번호') {
+      setInputData('');
+    } else if (labelName === '이메일') {
+      setInputData('tig@naver.com');
+    }
+  }, []);
+
+  const handleChangeInputData = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setInputData(ev.target.value);
+  };
+
+  const handleSaveNewInputData = (data: string) => {
+    // 실제로는 백엔드로 PATCH 요청이 전송된다.
+    // 일단은 전송이 성공적으로 이루어졌다고 가정
+    setInputData(data); // 한번 더 확실하게 데이터를 상태로 넣어주기 : 추후에 필요하면 삭제 가능
+    setInputBoxEditStage(1);
+  };
+
+  const toastUIDuration = 200;
+
+  const handleWrongEmailSave = () => {
+    if (toastId !== null) {
+      toast.remove(toastId);
+    }
+    const id = toast.custom(<ToastUI message="올바른 이메일이 아닙니다" />, {
+      duration: toastUIDuration,
+    });
+
+    setToastId(id);
+  };
+
+  const handleWrongPhoneNumberSave = () => {
+    if (toastId !== null) {
+      toast.remove(toastId);
+    }
+    const id = toast.custom(<ToastUI message="올바른 전화번호가 아닙니다" />, {
+      duration: toastUIDuration,
+    });
+
+    setToastId(id);
+  };
+
   return (
-    <div
-      className={cn('w-full h-fit flex justify-between items-center', {
-        'gap-x-[156px]': wholeGap === 156,
-        'gap-x-[59px]': wholeGap === 59,
-        'gap-x-[108px]': wholeGap === 108,
-      })}
-    >
-      <div
-        className={cn('flex justify-between items-center', {
-          'gap-x-[63px]': labelGap === 63,
-          'gap-x-[33px]': labelGap === 33,
-          'gap-x-[53px]': labelGap === 53,
-        })}
-      >
-        <span className="caption2 text-grey5">{labelName}</span>
-        <span
-          className={cn('body4', {
-            'text-grey7': placeholderColor === 'grey7',
-            'text-grey3': placeholderColor === 'grey3',
-          })}
-        >
-          {placeholderName}
-        </span>
-      </div>
-      <button
-        className={cn(
-          'w-fit h-fit rounded-md title4',
-          {
-            'text-grey7 bg-white shadow-mypageButton': isButtonBorder,
-            'text-white bg-primary_orange1': !isButtonBorder,
-          },
-          'px-[14px] py-[8px]'
+    <div className={cn('w-full h-fit flex items-center', {})}>
+      <span className="caption2 text-grey5 w-[84px]">{labelName}</span>
+      <div className="grow h-fit flex justify-between items-center">
+        {inputBoxEditStage === 1 && (
+          <span
+            className={cn('body4', {
+              'text-grey7': inputData !== '',
+              'text-grey3': inputData === '',
+            })}
+          >
+            {inputData !== '' ? inputData : `${labelName}을 입력해주세요`}
+          </span>
         )}
-      >
-        {buttonText}
-      </button>
+        {inputBoxEditStage === 2 && (
+          <input
+            value={inputData}
+            onChange={handleChangeInputData}
+            className="body4 text-grey7 shadow-writingReviewInput flex rounded-[4px] justify-start items-center pt-2 pl-2 pb-2"
+          />
+        )}
+        {inputBoxEditStage === 1 && inputData !== '' && (
+          <button
+            className="w-fit h-fit rounded-md title4 text-grey7 bg-white shadow-mypageButton px-[14px] py-[8px]"
+            onClick={() => setInputBoxEditStage(2)}
+          >
+            변경
+          </button>
+        )}
+        {inputBoxEditStage === 1 && inputData === '' && (
+          <button
+            className="w-fit h-fit rounded-md title4 text-white bg-primary_orange1  px-[14px] py-[8px]"
+            onClick={() => setInputBoxEditStage(2)}
+          >
+            입력
+          </button>
+        )}
+        {inputBoxEditStage === 2 && (
+          <button
+            className="w-fit h-fit rounded-md title4 text-white bg-primary_orange1 px-[14px] py-[8px]"
+            onClick={() => {
+              if (labelName === '이메일' && !isValidEmail(inputData)) {
+                // toastUI를 띄워주는 로직
+                handleWrongEmailSave();
+                return;
+              }
+
+              if (
+                labelName === '휴대폰번호' &&
+                !isValidPhoneNumber(inputData)
+              ) {
+                // toastUI를 띄워주는 로직
+                handleWrongPhoneNumberSave();
+                return;
+              }
+
+              handleSaveNewInputData(inputData);
+              toast.custom(<ToastUI message="변경이 완료되었습니다" />, {
+                duration: toastUIDuration,
+              });
+            }}
+          >
+            저장
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/mypage/ToastUI.tsx
+++ b/src/components/mypage/ToastUI.tsx
@@ -1,5 +1,7 @@
 import ToastTigSVG from '@public/svg/toastTig.svg';
 
+export const toastUIDuration = 200;
+
 export default function ToastUI({ message }: { message: string }) {
   return (
     <div className="w-[165px] h-10 bg-grey5 rounded-lg flex justify-center items-center gap-x-[5px]">

--- a/src/components/mypage/ToastUI.tsx
+++ b/src/components/mypage/ToastUI.tsx
@@ -1,12 +1,10 @@
 import ToastTigSVG from '@public/svg/toastTig.svg';
 
-export default function ToastUI() {
+export default function ToastUI({ message }: { message: string }) {
   return (
     <div className="w-[165px] h-10 bg-grey5 rounded-lg flex justify-center items-center gap-x-[5px]">
       <ToastTigSVG />
-      <span className="title4 text-secondary_green2">
-        변경이 완료되었습니다.
-      </span>
+      <span className="title4 text-secondary_green2">{message}</span>
     </div>
   );
 }

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -1,0 +1,41 @@
+// 백엔드로부터 예약 확정 정보를 받아오는 것이면 그냥 클라이언트 컴포넌트가 되어도 상관 없음
+'use client';
+import FortyEightTigSVG from '@public/svg/fortyEightTig.svg';
+// 하지만 사용자가 새로고침하면 전역 상태라고 하더라도 사라지기 때문에 백엔드로부터 받아오는 것이 더 맞지 않나싶음. 아니면 zustand persists
+import { usePaymentFirstStage } from '@store/paymentInfoStore';
+import HistoryComponentUpperSection from '@components/reservation-list/all/HistoryComponentUpperSection';
+
+export default function PaymentAfterConfirm() {
+  const firstStageInfoObject = usePaymentFirstStage(
+    (state) => state.firstStageInfoObject
+  );
+  return (
+    <section className="w-eightNineWidth flex flex-col items-center gap-y-10 pt-[78px]">
+      <div className="w-fit h-fit flex flex-col items-center">
+        <FortyEightTigSVG />
+        <span className="title2 text-grey6 mt-4 mb-2">
+          예약이 신청되었습니다.
+        </span>
+        <div className="text-grey6 mb-[14px]">
+          <span className="text-grey7 title2">확정여부를 메시지</span>로
+          알려드릴게요!
+        </div>
+        <div className="text-grey6">
+          확정까지 평균 소요 시간 :{' '}
+          <span className="title2 text-primary_orange1">1시간 이내</span>
+        </div>
+      </div>
+      <HistoryComponentUpperSection
+        companyName={firstStageInfoObject.companyName}
+        companyAddress={firstStageInfoObject.companyAddress}
+        eventDate={firstStageInfoObject.eventDate}
+        eventStartTime={firstStageInfoObject.eventStartTime}
+        eventEndTime={firstStageInfoObject.eventDate}
+        adultCount={firstStageInfoObject.adultCount}
+        youngManCount={firstStageInfoObject.youngManCount}
+        kidCount={firstStageInfoObject.kidCount}
+        className="bg-white p-5"
+      />
+    </section>
+  );
+}

--- a/src/components/payment/before/BeforeSecondStageCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageCard.tsx
@@ -4,7 +4,7 @@ import BeforeSecondStageFinalPriceCard from './BeforeSecondStageFinalPriceCard';
 
 interface BeforeSecondStageCardProps {
   userName: string;
-  phoneNumber: string | null;
+  phoneNumber: string;
   couponDiscountPrice: number;
   defaultPrice: number; // 기존의 예약 금액을 의미함
 }

--- a/src/components/payment/before/BeforeSecondStageUserInfoCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageUserInfoCard.tsx
@@ -1,12 +1,40 @@
+'use client';
+import { usePaymentSecondStage } from '@store/paymentInfoStore';
+import { ChangeEvent } from 'react';
+
 interface BeforeSecondStageUserInfoCardProps {
   userName: string;
-  phoneNumber: string | null;
+  phoneNumber: string;
 }
 
 export default function BeforeSecondStageUserInfoCard({
   userName,
   phoneNumber,
 }: BeforeSecondStageUserInfoCardProps) {
+  const secondStageInfoObject = usePaymentSecondStage(
+    (state) => state.secondStageInfoObject
+  );
+
+  const setSecondStageInfoObject = usePaymentSecondStage(
+    (state) => state.setSecondStageInfoObject
+  );
+
+  const handleChangeUserNameInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setSecondStageInfoObject({
+      ...secondStageInfoObject,
+      userName: event.target.value,
+    });
+  };
+
+  const handleChangeUserPhoneNumberInput = (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    setSecondStageInfoObject({
+      ...secondStageInfoObject,
+      phoneNumber: event.target.value,
+    });
+  };
+
   return (
     <div className="w-full h-fit rounded-[10px] flex flex-col items-center gap-y-5 bg-white py-5">
       <div className="w-sevenEightWidth h-fit flex flex-col gap-y-5">
@@ -18,6 +46,8 @@ export default function BeforeSecondStageUserInfoCard({
         <input
           type="text"
           value={userName}
+          onChange={handleChangeUserNameInput}
+          placeholder="예약자명 입력"
           className="w-[80%] border-b-[1px] border-grey3"
         />
       </div>
@@ -28,7 +58,8 @@ export default function BeforeSecondStageUserInfoCard({
         </span>
         <input
           type="text"
-          // value={userName}
+          value={phoneNumber}
+          onChange={handleChangeUserPhoneNumberInput}
           placeholder="휴대폰 번호 입력"
           className="placeholder:body4 placeholder:text-grey3 w-[80%] border-b-[1px] border-grey3"
         />

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-interface paymentFirstStageInfoProps {
+export interface paymentFirstStageInfoProps {
   companyName: string;
   companyAddress: string;
   eventDate: string;
@@ -34,7 +34,7 @@ export const usePaymentFirstStage = create<paymentFirstStageStore>((set) => ({
     set({ firstStageInfoObject: status }),
 }));
 
-interface paymentSecondStageInfoProps {
+export interface paymentSecondStageInfoProps {
   userName: string;
   phoneNumber: string;
   couponDiscountPrice: number;

--- a/src/types/mypage/MyPageTypes.ts
+++ b/src/types/mypage/MyPageTypes.ts
@@ -1,9 +1,3 @@
 export interface ProfileInformationItemProps {
-  wholeGap: number;
-  labelGap: number;
-  labelName: string;
-  placeholderName: string;
-  placeholderColor: string;
-  isButtonBorder: boolean;
-  buttonText: string;
+  labelName: '이름' | '휴대폰번호' | '이메일';
 }

--- a/src/utils/validationCheck.ts
+++ b/src/utils/validationCheck.ts
@@ -1,0 +1,12 @@
+export function isValidEmail(email: string) {
+  // 간단한 이메일 정규 표현식
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+export function isValidPhoneNumber(phoneNumber: string) {
+  // 간단한 전화번호 정규 표현식 (숫자, 하이픈, 괄호, 공백 허용)
+  const phoneRegex =
+    /^(?:\+?82-?|0)(?:10|(?:2|3[1-3]|4[1-4]|5[1-5]|6[1-4]))-?\d{3,4}-?\d{4}$/;
+  return phoneRegex.test(phoneNumber);
+}


### PR DESCRIPTION
## 🔎 작업 사항

### **/payment/before**
1. 연락처가 비었을 때 관련 모달 나타남
2. 연락처가 올바르지 않은 형식일 경우 관련 toastUI 나타남
3. `firstStageInfoObject`와 `secondStageInfoObject`를 전역 상태로 관리하며 이걸 백엔드로 보내면 됨

### **/payment/after**
1. 단순 페이지 구현
2. zustand persist를 이용해서 사용자가 ctrl r하는 현상을 막으면 될 것 같음(추후 예정)

