### PR TITLE
Fix/modal

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -4,8 +4,18 @@ import My from '@components/mypage/My';
 import NoneArrowHeader from '@components/all/NoneArrowHeader';
 import Modal from '@components/all/Modal';
 import { Toaster } from 'react-hot-toast';
+import { useEffect } from 'react';
+import useModal from '@store/modalStore';
 
-export default function page() {
+export default function Page() {
+  const setSelectedIsModalOpen = useModal(
+    (state) => state.setSelectedIsModalOpen
+  );
+
+  useEffect(() => {
+    return () => setSelectedIsModalOpen(false);
+  }, []);
+
   return (
     <div className="flex flex-col h-full pb-[54px] items-center">
       <NoneArrowHeader title="마이페이지" />

--- a/src/app/payment/before/[companyId]/page.tsx
+++ b/src/app/payment/before/[companyId]/page.tsx
@@ -71,6 +71,10 @@ export default function Page() {
     setSecondStageInfoObject(DUMMYSECONDSTAGEDATA);
   }, []);
 
+  useEffect(() => {
+    return () => setSelectedIsModalOpen(false);
+  }, []);
+
   return !isCouponPageOpen ? (
     <main className="w-full h-full flex flex-col items-center bg-grey1 pb-[100px] overflow-y-scroll">
       <Header

--- a/src/app/reservation-list/page.tsx
+++ b/src/app/reservation-list/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import NavBar from '@components/all/NavBar/NavBar';
 import HistoryHead from '@components/reservation-list/HistoryHead';
 import HistoryInProgressItem from '@components/reservation-list/HistoryInProgressItem';
@@ -11,6 +11,7 @@ import {
 import NoneResultUI from '@components/all/NoneResultUI/NoneResultUI';
 import NoneArrowHeader from '@components/all/NoneArrowHeader';
 import Modal from '@components/all/Modal';
+import useModal from '@store/modalStore';
 
 const MockReservationInProgressDataArray: HistoryInProgressItemProps[] = [
   {
@@ -134,6 +135,14 @@ export default function Page() {
   const [historyHeadState, setHistoryHeadState] = useState<
     '전체' | '진행중' | '종료된'
   >('전체');
+
+  const setSelectedIsModalOpen = useModal(
+    (state) => state.setSelectedIsModalOpen
+  );
+
+  useEffect(() => {
+    setSelectedIsModalOpen(false);
+  }, []);
 
   return (
     <div className="flex flex-col h-full pb-[54px] items-center">

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -23,12 +23,15 @@ const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
 };
 
 export default function Page() {
-  const setIsOpen = useModal((state) => state.setSelectedIsModalOpen);
+  const setIsSelectedModalOpen = useModal(
+    (state) => state.setSelectedIsModalOpen
+  );
   const [isReviewSubmitted, setIsReviewSubmitted] = useState(false);
   const router = useRouter();
+
   useEffect(() => {
     return () => {
-      setIsOpen(false);
+      setIsSelectedModalOpen(false);
     };
   }, []);
   return (

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -12,6 +12,7 @@ import { isValidPhoneNumber } from '@utils/validationCheck';
 import toast from 'react-hot-toast';
 import ToastUI, { toastUIDuration } from '@components/mypage/ToastUI';
 import { useState } from 'react';
+import { ButtonMouseEvent } from 'types/all/FullButtonTypes';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -39,6 +40,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | 'move-to-home-page'
     | 'move-to-second-payment-stage'
     | 'apply-coupon'
+    | 'cancel-reservation'
     | 'request-payment';
   sendingData?: {
     reviewId?: number;
@@ -103,7 +105,7 @@ export default function FullButton({
     status_red1: 'bg-status_red1',
     status_red1_opacity: 'bg-[#fdeeed]',
   };
-  function handleClickFullButton(ev: any) {
+  function handleClickFullButton(ev: ButtonMouseEvent) {
     if (clickTask === 'move-to-writing-review-page') {
       ev.stopPropagation();
       ev.preventDefault();
@@ -133,6 +135,12 @@ export default function FullButton({
       });
       setIsCouponPageOpen(false);
       return;
+    }
+
+    if (clickTask === 'cancel-reservation') {
+      setSelectedIsModalOpen(true);
+      ev.stopPropagation();
+      ev.preventDefault();
     }
 
     if (clickTask === 'request-payment') {
@@ -166,7 +174,7 @@ export default function FullButton({
 
   return (
     <button
-      onClick={(ev) => handleClickFullButton(ev)}
+      onClick={(ev: ButtonMouseEvent) => handleClickFullButton(ev)}
       className={cn(
         `w-full flex justify-center items-center rounded-md`,
         {

--- a/src/components/all/Header.tsx
+++ b/src/components/all/Header.tsx
@@ -50,7 +50,7 @@ export default function Header({
         className="w-[44px] h-[44px] flex items-center justify-center absolute left-0 cursor-pointer"
         onClick={() => {
           if (title === '리뷰 작성' && isReviewSubmitted === true) {
-            router.push('/');
+            router.replace('/');
             return;
           }
 

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -65,12 +65,8 @@ export default function HistoryInProgressItem({
             color="status_red1"
             size="sm"
             content="예약 취소"
+            clickTask="cancel-reservation"
             className="shadow-cancelButton"
-            onClick={(ev) => {
-              setModalOpen(true);
-              ev.stopPropagation();
-              ev.preventDefault();
-            }}
           />
           <FullButton
             bgColor="primary_orange1"

--- a/src/types/all/FullButtonTypes.ts
+++ b/src/types/all/FullButtonTypes.ts
@@ -1,0 +1,3 @@
+import { MouseEvent } from 'react';
+
+export type ButtonMouseEvent = MouseEvent<HTMLButtonElement>;


### PR DESCRIPTION
1. 모달을 여는 로직은 현재 `zustand` 중앙 상태 관리 저장소를 통해 이루어짐. 또한 button을 클릭하거나 FullButton 컴포넌트를 클릭하여 `isModalOpen` 상태가 true가 되는 방식을 진행됨.
2. `Modal` 컴포넌트를 사용하는 페이지들이 unmount될  때마다 `isModalOpen` 상태를 `useEffect()` 훅의 클린업 함수를 통해 false로 만들어주고 끝냄.