### PR TITLE
Feat/kakaologin 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "secure": "node server.js",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,32 @@
+const { createServer } = require('https');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+
+const hostname = 'localhost';
+const port = 3000;
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev, hostname, port });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: fs.readFileSync('./cert/localhost-key.pem'),
+  cert: fs.readFileSync('./cert/localhost.pem'),
+};
+
+app.prepare().then(() => {
+  createServer(httpsOptions, async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url, true);
+      await handle(req, res, parsedUrl);
+    } catch (err) {
+      console.error('Error occurred handling', req.url, err);
+      res.statusCode = 500;
+      res.end('internal server error');
+    }
+  }).listen(port, (err) => {
+    if (err) throw err;
+    console.log(`> Ready on https://${hostname}:${port}`);
+  });
+});

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function KakaoOuthCodeSendPage() {
+  const router = useRouter();
+  const data = useSearchParams();
+  const authCode = data?.get('code');
+
+  console.log(authCode);
+
+  useEffect(() => {
+    async function sendAuthCodeToBackend() {
+      try {
+        const response = await fetch(
+          `https://api.tigleisure.com/callback?code=${authCode}`
+        );
+
+        if (response.ok) {
+          const data = response.json();
+          console.log(data);
+          router.replace('/');
+        } else {
+          throw new Error(
+            '인증 코드를 기반으로 로그인 하는 데에 실패했습니다!'
+          );
+        }
+      } catch (error) {
+        alert(error);
+      }
+    }
+
+    if (authCode) {
+      sendAuthCodeToBackend();
+    }
+  }, [authCode]);
+  return <div>This is kakao login 리다이렉트 uri 페이지</div>;
+}

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -20,6 +20,7 @@ export default function KakaoOuthCodeSendPage() {
           const data = response.json();
           console.log(data);
           router.replace('/');
+          console.log('hi');
         } else {
           throw new Error(
             '인증 코드를 기반으로 로그인 하는 데에 실패했습니다!'

--- a/src/app/reservation-list/page.tsx
+++ b/src/app/reservation-list/page.tsx
@@ -141,7 +141,9 @@ export default function Page() {
   );
 
   useEffect(() => {
-    setSelectedIsModalOpen(false);
+    return () => {
+      setSelectedIsModalOpen(false);
+    };
   }, []);
 
   return (

--- a/src/components/login/SnsLogin.tsx
+++ b/src/components/login/SnsLogin.tsx
@@ -10,9 +10,7 @@ interface SnsLoginProps {
 function SnsLoginComponent({ companyName }: SnsLoginProps) {
   return (
     <Link
-      href={
-        'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=0307650b397857dfa903ca697df83f62&redirect_uri=http://localhost:3000/login/oauth2/code/kakao'
-      }
+      href={`https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=0307650b397857dfa903ca697df83f62&redirect_uri=${process.env.NEXT_PUBLIC_FRONTEND_DOMAIN}/login/oauth2/code/kakao`}
       id="kakaoLogo"
       className={cn(
         'w-full h-[47px] flex justify-center items-center rounded-[10px] hover:cursor-pointer',

--- a/src/components/login/SnsLogin.tsx
+++ b/src/components/login/SnsLogin.tsx
@@ -10,7 +10,9 @@ interface SnsLoginProps {
 function SnsLoginComponent({ companyName }: SnsLoginProps) {
   return (
     <Link
-      href={'https://tigleisure.com/oauth2/authorization/kakao'}
+      href={
+        'https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=0307650b397857dfa903ca697df83f62&redirect_uri=http://localhost:3000/login/oauth2/code/kakao'
+      }
       id="kakaoLogo"
       className={cn(
         'w-full h-[47px] flex justify-center items-center rounded-[10px] hover:cursor-pointer',
@@ -39,15 +41,7 @@ function SnsLoginComponent({ companyName }: SnsLoginProps) {
 export default function SnsLogin() {
   return (
     <div className="w-full h-fit flex flex-col justify-between items-center gap-y-[10px]">
-      {/* <Link
-        href={
-          'https://accounts.kakao.com/login/simple/?continue=https%3A%2F%2Fkauth.kakao.com%2Foauth%2Fauthorize%3Fscope%3Dprofile_nickname%2520profile_image%2520account_email%26response_type%3Dcode%26state%3DoFl5DpLznv_lgG-V7DYcVjcZ0LkO61KJGVlC4UEFH9w%253D%26redirect_uri%3Dhttp%253A%252F%252F13.209.131.90%253A8080%252Flogin%252Foauth2%252Fcode%252Fkakao%26through_account%3Dtrue%26client_id%3D0307650b397857dfa903ca697df83f62&talk_login=#simpleLogin'
-        }
-        className="w-full"
-      >
-        </Link> */}
       <SnsLoginComponent companyName="kakao" />
-
       <SnsLoginComponent companyName="google" />
     </div>
   );


### PR DESCRIPTION
## 🕹️ 개요
localhost에서 카카오 로그인 구현

## 🔎 작업 사항
1. 아까 보내준 localhost https 설정을 일단 끝내야함.
2. server.js는 내가 만들어서 push해놨음
3. 실제 개발 서버 돌리려면 이제는 `npm run secure`로 해야됨
4. /login/oauth2/code/kakao 페이지에서 인증코드 받아서 백엔드에 보낸 뒤, 쿠키 박히면 홈으로 리다이렉트
5. `.env` 파일에 **NEXT_PUBLIC_FRONTEND_DOMAIN=https://localhost:3000** 추가 부탁
## 📋 작업 브랜치
