### PR TITLE
[Fix] : wrap kakao oauth 페이지 in Suspense for 배포

### DIFF
--- a/src/app/login/oauth2/code/kakao/KakaoLoginLogic.tsx
+++ b/src/app/login/oauth2/code/kakao/KakaoLoginLogic.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function KakaoLoginLogic() {
+  const router = useRouter();
+  const data = useSearchParams();
+  const authCode = data?.get('code');
+
+  useEffect(() => {
+    async function sendAuthCodeToBackend() {
+      try {
+        const response = await fetch(
+          `https://api.tigleisure.com/callback?code=${authCode}`,
+          {
+            credentials: 'include',
+          }
+        );
+
+        if (response.ok) {
+          const data = response.json();
+          console.log(data);
+          router.replace('/');
+          console.log('hi');
+        } else {
+          throw new Error(
+            '인증 코드를 기반으로 로그인 하는 데에 실패했습니다!'
+          );
+        }
+      } catch (error) {
+        alert(error);
+      }
+    }
+
+    if (authCode) {
+      sendAuthCodeToBackend();
+    }
+  }, [authCode]);
+  return <div>This is kakao login 리다이렉트 uri 페이지</div>;
+}

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,42 +1,10 @@
-'use client';
-import { useEffect } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense } from 'react';
+import KakaoLoginLogic from './KakaoLoginLogic';
 
 export default function KakaoOuthCodeSendPage() {
-  const router = useRouter();
-  const data = useSearchParams();
-  const authCode = data?.get('code');
-
-  console.log(authCode);
-
-  useEffect(() => {
-    async function sendAuthCodeToBackend() {
-      try {
-        const response = await fetch(
-          `https://api.tigleisure.com/callback?code=${authCode}`,
-          {
-            credentials: 'include',
-          }
-        );
-
-        if (response.ok) {
-          const data = response.json();
-          console.log(data);
-          router.replace('/');
-          console.log('hi');
-        } else {
-          throw new Error(
-            '인증 코드를 기반으로 로그인 하는 데에 실패했습니다!'
-          );
-        }
-      } catch (error) {
-        alert(error);
-      }
-    }
-
-    if (authCode) {
-      sendAuthCodeToBackend();
-    }
-  }, [authCode]);
-  return <div>This is kakao login 리다이렉트 uri 페이지</div>;
+  return (
+    <Suspense>
+      <KakaoLoginLogic />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
kakao oauth 페이지에서 useSearchParams() 훅을 쓰고 있기에 이를 suspense 컴포넌트에 wrapping해줌. for 배포