### PR TITLE
Feat/reservation list

### DIFF
--- a/src/app/reservation-list/page.tsx
+++ b/src/app/reservation-list/page.tsx
@@ -7,134 +7,149 @@ import HistoryEndItem from '@components/reservation-list/HistoryEndItem';
 import {
   HistoryInProgressItemProps,
   HistoryEndItemProps,
+  ReservationItemProps,
 } from 'types/reservation-list/ReservationListPageTypes';
 import NoneResultUI from '@components/all/NoneResultUI/NoneResultUI';
 import NoneArrowHeader from '@components/all/NoneArrowHeader';
 import Modal from '@components/all/Modal';
 import useModal from '@store/modalStore';
 
-const MockReservationInProgressDataArray: HistoryInProgressItemProps[] = [
-  {
-    companyName:
-      '스카이락볼링장 asfdasdfsdafdasfasdfasdfasdfsadfasdfsdafasdfsdafsadfdasfasdfasdfsdafdsafasdfasdf',
-    companyAddress:
-      '서울 서대문구 신촌로 73 asdfasdfsdafdsafsdafsadfasdfdsafdasfasdfsdafsdfasdfasdfsdafsdafsdafasdfsdfasdfasdfsd',
-    eventDate: '05.17 (금)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 2,
-    reservationStatus: 'inProgress',
-    reservationId: 1,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.28 (화)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    reservationStatus: 'inProgress',
-    reservationId: 2,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.10 (수)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    reservationStatus: 'confirmed',
-    reservationId: 3,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    reservationStatus: 'confirmed',
-    reservationId: 4,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    reservationStatus: 'inProgress',
-    reservationId: 5,
-  },
-];
+// const MockReservationInProgressDataArray: HistoryInProgressItemProps[] = [
+//   {
+//     companyName:
+//       '스카이락볼링장 asfdasdfsdafdasfasdfasdfasdfsadfasdfsdafasdfsdafsadfdasfasdfasdfsdafdsafasdfasdf',
+//     companyAddress:
+//       '서울 서대문구 신촌로 73 asdfasdfsdafdsafsdafsadfasdfdsafdasfasdfsdafsdfasdfasdfsdafsdafsdafasdfsdfasdfasdfsd',
+//     eventDate: '05.17 (금)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 2,
+//     reservationStatus: 'inProgress',
+//     reservationId: 1,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.28 (화)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     reservationStatus: 'inProgress',
+//     reservationId: 2,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.10 (수)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     reservationStatus: 'confirmed',
+//     reservationId: 3,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     reservationStatus: 'confirmed',
+//     reservationId: 4,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     reservationStatus: 'inProgress',
+//     reservationId: 5,
+//   },
+// ];
 
-const MockReservationEndDataArray: HistoryEndItemProps[] = [
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.10 (수)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'alreadyReviewed',
-    reservationId: 1,
-    reviewId: 1,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'notYetReviewed',
-    reservationId: 2,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'denied',
-    reservationId: 3,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'canceled',
-    reservationId: 4,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.10 (수)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'denied',
-    reservationId: 5,
-  },
-  {
-    companyName: '스카이락볼링장',
-    companyAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.05 (일)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 8,
-    closedReservationStatus: 'notYetReviewed',
-    reservationId: 6,
-  },
-];
+// const MockReservationEndDataArray: HistoryEndItemProps[] = [
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.10 (수)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'alreadyReviewed',
+//     reservationId: 1,
+//     reviewId: 1,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'notYetReviewed',
+//     reservationId: 2,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'denied',
+//     reservationId: 3,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'canceled',
+//     reservationId: 4,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.10 (수)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'denied',
+//     reservationId: 5,
+//   },
+//   {
+//     companyName: '스카이락볼링장',
+//     companyAddress: '서울 서대문구 신촌로 73',
+//     eventDate: '05.05 (일)',
+//     eventStartTime: '오전 10:00',
+//     eventEndTime: '오전 11:00',
+//     adultCount: 8,
+//     closedReservationStatus: 'notYetReviewed',
+//     reservationId: 6,
+//   },
+// ];
+
 export default function Page() {
   const [historyHeadState, setHistoryHeadState] = useState<
     '전체' | '진행중' | '종료된'
   >('전체');
+  const [reservationList, setReservationList] = useState<
+    ReservationItemProps[]
+  >([]);
+
+  const inProgressReservationList = reservationList.filter(
+    (reservationItem) =>
+      reservationItem.status === 'CONFIRMED' || reservationItem.status === 'TBC'
+  );
+
+  const endReservationList = reservationList.filter(
+    (reservationItem) =>
+      reservationItem.status !== 'CONFIRMED' && reservationItem.status !== 'TBC'
+  );
 
   const setSelectedIsModalOpen = useModal(
     (state) => state.setSelectedIsModalOpen
@@ -146,17 +161,40 @@ export default function Page() {
     };
   }, []);
 
+  useEffect(() => {
+    async function getReservationList() {
+      try {
+        const response = await fetch(
+          'https://api.tigleisure.com/api/v1/reservation',
+          {
+            credentials: 'include',
+          }
+        );
+
+        const data = await response.json();
+
+        console.log(data);
+
+        setReservationList(data);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    getReservationList();
+  }, []);
+
   return (
     <div className="flex flex-col h-full pb-[54px] items-center">
       <NoneArrowHeader title="예약내역" />
       <HistoryHead
-        totalCount={5}
-        inProgressCount={3}
-        completedCount={2}
+        totalCount={reservationList.length}
+        inProgressCount={inProgressReservationList.length}
+        completedCount={endReservationList.length}
         historyHeadState={historyHeadState}
         handleHeadState={setHistoryHeadState}
       />
-      {historyHeadState === '전체' && (
+      {historyHeadState === '전체' && reservationList.length === 0 && (
         <main className="w-full h-full flex flex-col top-[117px] justify-center items-center gap-y-[10px] overflow-y-scroll">
           <NoneResultUI
             message="예약 내역이 없어요"
@@ -164,38 +202,93 @@ export default function Page() {
           />
         </main>
       )}
-      {historyHeadState === '진행중' && (
+
+      {historyHeadState === '전체' && reservationList.length !== 0 && (
         <main className="w-full max-h-reservationListMain pt-5 pb-10 flex flex-col top-[117px] absolute justify-start items-center gap-y-[10px] overflow-y-scroll">
-          {MockReservationInProgressDataArray.map((data, index) => (
-            <HistoryInProgressItem
-              key={index}
-              companyName={data.companyName}
-              companyAddress={data.companyAddress}
-              eventDate={data.eventDate}
-              eventStartTime={data.eventStartTime}
-              eventEndTime={data.eventEndTime}
-              adultCount={data.adultCount}
-              reservationStatus={data.reservationStatus}
-              reservationId={data.reservationId}
-            />
-          ))}
+          {reservationList.map((reservationItem, index) =>
+            reservationItem.status === 'TBC' ||
+            reservationItem.status === 'CONFIRMED' ? (
+              <HistoryInProgressItem
+                key={index}
+                companyName={reservationItem.clubName}
+                companyAddress={reservationItem.clubAddress}
+                eventDate={reservationItem.date}
+                eventStartTime={reservationItem.startTime}
+                eventEndTime={reservationItem.endTime}
+                adultCount={reservationItem.adultCount}
+                reservationStatus={reservationItem.status}
+                reservationId={index}
+              />
+            ) : (
+              <HistoryEndItem
+                key={index}
+                companyName={reservationItem.clubName}
+                companyAddress={reservationItem.clubAddress}
+                eventDate={reservationItem.date}
+                eventStartTime={reservationItem.startTime}
+                eventEndTime={reservationItem.endTime}
+                adultCount={reservationItem.adultCount}
+                reservationStatus={reservationItem.status}
+                reservationId={index} //일단 백엔드에서 추후에 예약과 review id를 줌
+                reviewId={index}
+              />
+            )
+          )}
         </main>
       )}
 
-      {historyHeadState === '종료된' && (
+      {historyHeadState === '진행중' &&
+        inProgressReservationList.length === 0 && (
+          <main className="w-full h-full flex flex-col top-[117px] justify-center items-center gap-y-[10px] overflow-y-scroll">
+            <NoneResultUI
+              message="예약 내역이 없어요"
+              subMessage="마음에 드는 장소를 찾아 예약해보세요!"
+            />
+          </main>
+        )}
+
+      {historyHeadState === '진행중' &&
+        inProgressReservationList.length !== 0 && (
+          <main className="w-full max-h-reservationListMain pt-5 pb-10 flex flex-col top-[117px] absolute justify-start items-center gap-y-[10px] overflow-y-scroll">
+            {inProgressReservationList.map((data, index) => (
+              <HistoryInProgressItem
+                key={index}
+                companyName={data.clubName}
+                companyAddress={data.clubAddress}
+                eventDate={data.date}
+                eventStartTime={data.startTime}
+                eventEndTime={data.endTime}
+                adultCount={data.adultCount}
+                reservationStatus={data.status}
+                reservationId={index}
+              />
+            ))}
+          </main>
+        )}
+
+      {historyHeadState === '종료된' && endReservationList.length === 0 && (
+        <main className="w-full h-full flex flex-col top-[117px] justify-center items-center gap-y-[10px] overflow-y-scroll">
+          <NoneResultUI
+            message="예약 내역이 없어요"
+            subMessage="마음에 드는 장소를 찾아 예약해보세요!"
+          />
+        </main>
+      )}
+
+      {historyHeadState === '종료된' && endReservationList.length !== 0 && (
         <main className="w-full max-h-reservationListMain pt-5 pb-10 flex flex-col top-[117px] absolute justify-start items-center gap-y-[10px] overflow-y-scroll">
-          {MockReservationEndDataArray.map((data, index) => (
+          {endReservationList.map((data, index) => (
             <HistoryEndItem
               key={index}
-              companyName={data.companyName}
-              companyAddress={data.companyAddress}
-              eventDate={data.eventDate}
-              eventStartTime={data.eventStartTime}
-              eventEndTime={data.eventEndTime}
+              companyName={data.clubName}
+              companyAddress={data.clubAddress}
+              eventDate={data.date}
+              eventStartTime={data.startTime}
+              eventEndTime={data.endTime}
               adultCount={data.adultCount}
-              closedReservationStatus={data.closedReservationStatus}
-              reservationId={data.reservationId}
-              reviewId={data.reviewId}
+              reservationStatus={data.status}
+              reservationId={index}
+              reviewId={index}
             />
           ))}
         </main>

--- a/src/app/search/result/SearchResult.tsx
+++ b/src/app/search/result/SearchResult.tsx
@@ -145,7 +145,7 @@ const isResult = true;
 export function SearchResult() {
   const tabArray = allleisureArray;
   const searchParams = useSearchParams();
-  const { search, date, adultCount, teenagerCount, kidCount } =
+  const { search, date, adultCount, teenagerCount, kidsCount } =
     Object.fromEntries(searchParams.entries());
 
   const selectedTab = useTab((state) => state.selectedTab);
@@ -170,7 +170,7 @@ export function SearchResult() {
         placeholder={`${search}, ${date}${
           adultCount === '0' ? '' : `, 성인 ${adultCount}명`
         }${teenagerCount === '0' ? '' : `, 청소년 ${teenagerCount}명`}${
-          kidCount === '0' ? '' : `, 어린이 ${kidCount}명 `
+          kidsCount === '0' ? '' : `, 어린이 ${kidsCount}명 `
         }`}
         isHomeOrResultPage
       />

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import NavBar from '@components/all/NavBar/NavBar';
 import Tabs from '@components/all/Tabs/Tabs';
 import { allleisureArray } from '@constant/constant';
@@ -5,6 +7,7 @@ import NoneArrowHeader from '@components/all/NoneArrowHeader';
 import { ResultCardProps } from 'types/search/result/searchResult';
 import ResultCard from '@components/search/result/ResultCard';
 import { da } from 'date-fns/locale';
+import { useEffect } from 'react';
 
 const DUMMYRESULTS: ResultCardProps[] = [
   {
@@ -134,7 +137,24 @@ const DUMMYRESULTS: ResultCardProps[] = [
   },
 ];
 
-export default function page() {
+export default function Page() {
+  useEffect(() => {
+    async function getWishlist() {
+      const response = await fetch(
+        'https://api.tigleisure.com/api/v1/wishlist',
+        {
+          credentials: 'include',
+        }
+      );
+
+      const data = await response.json();
+
+      console.log(data);
+    }
+
+    getWishlist();
+  }, []);
+
   const tabArray = allleisureArray;
   return (
     <div className="flex flex-col h-full mb-[54px] items-center">

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -55,7 +55,7 @@ export default function Page() {
                 eventEndTime={DUMMYREVIEWDATA.eventEndTime}
                 eventStartTime={DUMMYREVIEWDATA.eventStartTime}
                 adultCount={DUMMYREVIEWDATA.adultCount}
-                youngManCount={DUMMYREVIEWDATA.youngManCount}
+                teenagerCount={DUMMYREVIEWDATA.teenagerCount}
                 kidCount={DUMMYREVIEWDATA.kidCount}
               />
             </div>
@@ -133,7 +133,7 @@ export default function Page() {
                 eventEndTime={DUMMYREVIEWDATA.eventEndTime}
                 eventStartTime={DUMMYREVIEWDATA.eventStartTime}
                 adultCount={DUMMYREVIEWDATA.adultCount}
-                youngManCount={DUMMYREVIEWDATA.youngManCount}
+                teenagerCount={DUMMYREVIEWDATA.teenagerCount}
                 kidCount={DUMMYREVIEWDATA.kidCount}
               />
               <div className="w-full border-b-[1px] border-grey2" />

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
                 eventStartTime={DUMMYREVIEWDATA.eventStartTime}
                 adultCount={DUMMYREVIEWDATA.adultCount}
                 teenagerCount={DUMMYREVIEWDATA.teenagerCount}
-                kidCount={DUMMYREVIEWDATA.kidCount}
+                kidsCount={DUMMYREVIEWDATA.kidsCount}
               />
             </div>
             <div className="w-full h-fit rounded-[10px] bg-white py-5 px-[110px] flex flex-col gap-y-[10px] items-center">
@@ -134,7 +134,7 @@ export default function Page() {
                 eventStartTime={DUMMYREVIEWDATA.eventStartTime}
                 adultCount={DUMMYREVIEWDATA.adultCount}
                 teenagerCount={DUMMYREVIEWDATA.teenagerCount}
-                kidCount={DUMMYREVIEWDATA.kidCount}
+                kidsCount={DUMMYREVIEWDATA.kidsCount}
               />
               <div className="w-full border-b-[1px] border-grey2" />
               <ReviewLowerSection

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -35,7 +35,7 @@ export default function PaymentAfterConfirm() {
         eventEndTime={firstStageInfoObject.eventDate}
         adultCount={firstStageInfoObject.adultCount}
         teenagerCount={firstStageInfoObject.teenagerCount}
-        kidCount={firstStageInfoObject.kidCount}
+        kidsCount={firstStageInfoObject.kidsCount}
         className="bg-white p-5"
       />
     </section>

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -34,7 +34,7 @@ export default function PaymentAfterConfirm() {
         eventStartTime={firstStageInfoObject.eventStartTime}
         eventEndTime={firstStageInfoObject.eventDate}
         adultCount={firstStageInfoObject.adultCount}
-        youngManCount={firstStageInfoObject.youngManCount}
+        teenagerCount={firstStageInfoObject.teenagerCount}
         kidCount={firstStageInfoObject.kidCount}
         className="bg-white p-5"
       />

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -4,7 +4,7 @@ interface BeforeFirstStageCardProps {
   eventDate: string;
   adultCount?: number;
   teenagerCount?: number;
-  kidCount?: number;
+  kidsCount?: number;
   eventStartTime: string;
   eventEndTime: string;
   stageFirstPrice: number;
@@ -16,7 +16,7 @@ export default function BeforeFirstStageCard({
   eventDate,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   eventStartTime,
   eventEndTime,
   stageFirstPrice,
@@ -38,7 +38,7 @@ export default function BeforeFirstStageCard({
           <span className="body4 text-grey6">
             {adultCount && `성인 ${adultCount}명 `}{' '}
             {teenagerCount && `청소년 ${teenagerCount}명 `}{' '}
-            {kidCount && `어린이 ${kidCount}명`}
+            {kidsCount && `어린이 ${kidsCount}명`}
           </span>
         </div>
         <div className="w-full flex justify-between items-center">

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -3,7 +3,7 @@ interface BeforeFirstStageCardProps {
   companyAddress: string;
   eventDate: string;
   adultCount?: number;
-  youngManCount?: number;
+  teenagerCount?: number;
   kidCount?: number;
   eventStartTime: string;
   eventEndTime: string;
@@ -15,7 +15,7 @@ export default function BeforeFirstStageCard({
   companyAddress,
   eventDate,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   eventStartTime,
   eventEndTime,
@@ -37,7 +37,7 @@ export default function BeforeFirstStageCard({
           <span className="title text-grey4">인원</span>
           <span className="body4 text-grey6">
             {adultCount && `성인 ${adultCount}명 `}{' '}
-            {youngManCount && `청소년 ${youngManCount}명 `}{' '}
+            {teenagerCount && `청소년 ${teenagerCount}명 `}{' '}
             {kidCount && `어린이 ${kidCount}명`}
           </span>
         </div>

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -12,7 +12,7 @@ export default function HistoryEndItem({
   eventEndTime,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   closedReservationStatus,
   reservationId,
   reviewId,
@@ -30,7 +30,7 @@ export default function HistoryEndItem({
         eventEndTime={eventEndTime}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
-        kidCount={kidCount}
+        kidsCount={kidsCount}
       />
       {closedReservationStatus === 'notYetReviewed' && (
         <FullButton

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -13,7 +13,7 @@ export default function HistoryEndItem({
   adultCount,
   teenagerCount,
   kidsCount,
-  closedReservationStatus,
+  reservationStatus,
   reservationId,
   reviewId,
 }: HistoryEndItemProps) {
@@ -32,7 +32,7 @@ export default function HistoryEndItem({
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}
       />
-      {closedReservationStatus === 'notYetReviewed' && (
+      {reservationStatus === 'DONE' && (
         <FullButton
           size="sm"
           color="white"
@@ -44,7 +44,7 @@ export default function HistoryEndItem({
           }}
         />
       )}
-      {closedReservationStatus === 'alreadyReviewed' && (
+      {reservationStatus === 'REVIEWED' && (
         <FullButton
           size="sm"
           color="grey5"
@@ -57,7 +57,7 @@ export default function HistoryEndItem({
           }}
         />
       )}
-      {closedReservationStatus === 'denied' && (
+      {reservationStatus === 'DECLINED' && (
         <FullButton
           bgColor="grey3"
           color="white"
@@ -66,7 +66,7 @@ export default function HistoryEndItem({
           disabled
         />
       )}
-      {closedReservationStatus === 'canceled' && (
+      {reservationStatus === 'CANCELED' && (
         <FullButton
           bgColor="status_red1_opacity"
           color="status_red1"

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -11,7 +11,7 @@ export default function HistoryEndItem({
   eventStartTime,
   eventEndTime,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   closedReservationStatus,
   reservationId,
@@ -29,7 +29,7 @@ export default function HistoryEndItem({
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
         adultCount={adultCount}
-        youngManCount={youngManCount}
+        teenagerCount={teenagerCount}
         kidCount={kidCount}
       />
       {closedReservationStatus === 'notYetReviewed' && (

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -13,7 +13,7 @@ export default function HistoryInProgressItem({
   eventEndTime,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   reservationStatus,
   reservationId,
 }: HistoryInProgressItemProps) {
@@ -32,7 +32,7 @@ export default function HistoryInProgressItem({
         eventEndTime={eventEndTime}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
-        kidCount={kidCount}
+        kidsCount={kidsCount}
       />
       {reservationStatus === 'inProgress' && (
         <div className="w-full h-fit flex gap-[10px]">

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -34,7 +34,7 @@ export default function HistoryInProgressItem({
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}
       />
-      {reservationStatus === 'inProgress' && (
+      {reservationStatus === 'TBC' && (
         <div className="w-full h-fit flex gap-[10px]">
           <FullButton
             bgColor="white"
@@ -58,7 +58,7 @@ export default function HistoryInProgressItem({
         </div>
       )}
 
-      {reservationStatus === 'confirmed' && (
+      {reservationStatus === 'CONFIRMED' && (
         <div className="w-full h-fit flex gap-[10px]">
           <FullButton
             bgColor="white"

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -12,7 +12,7 @@ export default function HistoryInProgressItem({
   eventStartTime,
   eventEndTime,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   reservationStatus,
   reservationId,
@@ -31,7 +31,7 @@ export default function HistoryInProgressItem({
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
         adultCount={adultCount}
-        youngManCount={youngManCount}
+        teenagerCount={teenagerCount}
         kidCount={kidCount}
       />
       {reservationStatus === 'inProgress' && (

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -12,7 +12,7 @@ export default function HistoryComponentUpperSection({
   eventStartTime,
   eventEndTime,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   className,
 }: HistoryComponentUpperSectionProps) {
@@ -46,7 +46,7 @@ export default function HistoryComponentUpperSection({
             <SmallPersonSVG />
             <span className="body4 text-grey7">
               {adultCount && `성인 ${adultCount}명`}
-              {youngManCount && `청소년 ${youngManCount}명`}
+              {teenagerCount && `청소년 ${teenagerCount}명`}
               {kidCount && `어린이 ${kidCount}명`}
             </span>
           </div>

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -13,7 +13,7 @@ export default function HistoryComponentUpperSection({
   eventEndTime,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   className,
 }: HistoryComponentUpperSectionProps) {
   return (
@@ -47,7 +47,7 @@ export default function HistoryComponentUpperSection({
             <span className="body4 text-grey7">
               {adultCount && `성인 ${adultCount}명`}
               {teenagerCount && `청소년 ${teenagerCount}명`}
-              {kidCount && `어린이 ${kidCount}명`}
+              {kidsCount && `어린이 ${kidsCount}명`}
             </span>
           </div>
         </div>

--- a/src/components/reservation-list/reservation/HistoryDetail.tsx
+++ b/src/components/reservation-list/reservation/HistoryDetail.tsx
@@ -15,7 +15,7 @@ export default function HistoryDetail({
   eventEndTime,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   reservationNumber,
   reservationUserName,
   phoneNumber,
@@ -36,7 +36,7 @@ export default function HistoryDetail({
         eventEndTime={eventEndTime}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
-        kidCount={kidCount}
+        kidsCount={kidsCount}
       />
       <div className="w-full border-[1px] border-grey2" />
       <ReservationInfoSection

--- a/src/components/reservation-list/reservation/HistoryDetail.tsx
+++ b/src/components/reservation-list/reservation/HistoryDetail.tsx
@@ -14,7 +14,7 @@ export default function HistoryDetail({
   eventStartTime,
   eventEndTime,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   reservationNumber,
   reservationUserName,
@@ -35,7 +35,7 @@ export default function HistoryDetail({
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
         adultCount={adultCount}
-        youngManCount={youngManCount}
+        teenagerCount={teenagerCount}
         kidCount={kidCount}
       />
       <div className="w-full border-[1px] border-grey2" />

--- a/src/components/reservation-list/review/Review.tsx
+++ b/src/components/reservation-list/review/Review.tsx
@@ -11,7 +11,7 @@ export default function Review({
   eventEndTime,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   reservationUserName,
   rating,
   rateContent,
@@ -27,7 +27,7 @@ export default function Review({
         eventEndTime={eventEndTime}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
-        kidCount={kidCount}
+        kidsCount={kidsCount}
       />
       <div className="w-full border-[1px] border-grey2" />
 
@@ -36,7 +36,7 @@ export default function Review({
         eventDate={eventDate}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
-        kidCount={kidCount}
+        kidsCount={kidsCount}
         rating={rating}
         rateContent={rateContent}
         className="!px-0"

--- a/src/components/reservation-list/review/Review.tsx
+++ b/src/components/reservation-list/review/Review.tsx
@@ -10,7 +10,7 @@ export default function Review({
   eventStartTime,
   eventEndTime,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   reservationUserName,
   rating,
@@ -26,7 +26,7 @@ export default function Review({
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
         adultCount={adultCount}
-        youngManCount={youngManCount}
+        teenagerCount={teenagerCount}
         kidCount={kidCount}
       />
       <div className="w-full border-[1px] border-grey2" />
@@ -35,7 +35,7 @@ export default function Review({
         reservationUserName={reservationUserName}
         eventDate={eventDate}
         adultCount={adultCount}
-        youngManCount={youngManCount}
+        teenagerCount={teenagerCount}
         kidCount={kidCount}
         rating={rating}
         rateContent={rateContent}

--- a/src/components/reservation-list/review/ReviewLowerSection.tsx
+++ b/src/components/reservation-list/review/ReviewLowerSection.tsx
@@ -7,7 +7,7 @@ export default function ReviewLowerSection({
   reservationUserName,
   eventDate,
   adultCount,
-  youngManCount,
+  teenagerCount,
   kidCount,
   rating,
   rateContent,
@@ -24,7 +24,7 @@ export default function ReviewLowerSection({
           <p className="caption2 text-grey3">|</p>
           <p className="caption2 text-grey4">
             {adultCount && `성인 ${adultCount}명 `}
-            {youngManCount && `청소년 ${youngManCount}명 `}
+            {teenagerCount && `청소년 ${teenagerCount}명 `}
             {kidCount && `어린이 ${kidCount}명 `}
           </p>
         </div>

--- a/src/components/reservation-list/review/ReviewLowerSection.tsx
+++ b/src/components/reservation-list/review/ReviewLowerSection.tsx
@@ -8,7 +8,7 @@ export default function ReviewLowerSection({
   eventDate,
   adultCount,
   teenagerCount,
-  kidCount,
+  kidsCount,
   rating,
   rateContent,
   className,
@@ -25,7 +25,7 @@ export default function ReviewLowerSection({
           <p className="caption2 text-grey4">
             {adultCount && `성인 ${adultCount}명 `}
             {teenagerCount && `청소년 ${teenagerCount}명 `}
-            {kidCount && `어린이 ${kidCount}명 `}
+            {kidsCount && `어린이 ${kidsCount}명 `}
           </p>
         </div>
       </div>

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -18,7 +18,7 @@ export default function MakeResButtonCard() {
   const handleReservation = () => {
     if (pathname.startsWith('/reservation/game')) {
       console.log('gameResInfo', gameResInfo);
-      const query ={
+      const query = {
         gametype: 'game',
         date: gameResInfo.date,
         startTime: gameResInfo.startTime,
@@ -26,7 +26,7 @@ export default function MakeResButtonCard() {
         price: '금액 by BE',
         adultCount: String(gameResInfo.adultCount),
         teenagerCount: String(gameResInfo.teenagerCount),
-        kidCount: String(gameResInfo.kidCount),
+        kidsCount: String(gameResInfo.kidsCount),
         companyName: '회사 이름 by BE',
         companyAddress: '회사 주소 by BE',
       };
@@ -34,7 +34,7 @@ export default function MakeResButtonCard() {
       router.push(`/payment/before/1?${queryString}`);
     } else {
       console.log('timeResInfo', timeResInfo);
-      const query ={
+      const query = {
         gametype: 'time',
         date: gameResInfo.date,
         startTime: gameResInfo.startTime,
@@ -42,7 +42,7 @@ export default function MakeResButtonCard() {
         price: '금액 by BE',
         adultCount: String(gameResInfo.adultCount),
         teenagerCount: String(gameResInfo.teenagerCount),
-        kidCount: String(gameResInfo.kidCount),
+        kidsCount: String(gameResInfo.kidsCount),
         companyName: '회사 이름 by BE',
         companyAddress: '회사 주소 by BE',
       };

--- a/src/components/search/ButtonCard.tsx
+++ b/src/components/search/ButtonCard.tsx
@@ -14,7 +14,7 @@ export default function ButtonCard() {
       date: inputValue.searchDate,
       adultCount: String(inputValue.adultCount),
       teenagerCount: String(inputValue.teenagerCount),
-      kidCount: String(inputValue.kidCount),
+      kidsCount: String(inputValue.kidsCount),
     };
     const queryString = new URLSearchParams(query).toString();
     router.push(`/search/result?${queryString}`);

--- a/src/components/search/ChooseCard.tsx
+++ b/src/components/search/ChooseCard.tsx
@@ -67,7 +67,7 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidGameResCount({
           ...inputGameResValue,
-          kidCount: inputGameResValue.kidCount - 1,
+          kidsCount: inputGameResValue.kidsCount - 1,
         });
       }
     } else if (pathname.startsWith('/reservation/time')) {
@@ -84,7 +84,7 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidTimeResCount({
           ...inputTimeResValue,
-          kidCount: inputTimeResValue.kidCount - 1,
+          kidsCount: inputTimeResValue.kidsCount - 1,
         });
       }
     } else {
@@ -102,7 +102,7 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidSearchCount({
           ...inputSearchValue,
-          kidCount: inputSearchValue.kidCount - 1,
+          kidsCount: inputSearchValue.kidsCount - 1,
         });
       }
     }
@@ -124,7 +124,7 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidGameResCount({
           ...inputGameResValue,
-          kidCount: inputGameResValue.kidCount + 1,
+          kidsCount: inputGameResValue.kidsCount + 1,
         });
       }
     } else if (pathname.startsWith('/reservation/time')) {
@@ -141,10 +141,11 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidTimeResCount({
           ...inputTimeResValue,
-          kidCount: inputTimeResValue.kidCount + 1,
+          kidsCount: inputTimeResValue.kidsCount + 1,
         });
       }
-    } else { // search
+    } else {
+      // search
       if (title === '성인') {
         setAdultSearchCount({
           ...inputSearchValue,
@@ -158,11 +159,10 @@ export default function ChooseCard({ title, description }: ChooseCardProps) {
       } else if (title === '어린이') {
         setKidSearchCount({
           ...inputSearchValue,
-          kidCount: inputSearchValue.kidCount + 1,
+          kidsCount: inputSearchValue.kidsCount + 1,
         });
       }
     }
-    
   };
 
   return (

--- a/src/store/makeReservationInfo.ts
+++ b/src/store/makeReservationInfo.ts
@@ -6,7 +6,7 @@ interface MakeReservationInfoProps {
   startTime: string;
   adultCount: number;
   teenagerCount: number;
-  kidCount: number;
+  kidsCount: number;
   askToManager: string;
 }
 interface MakeGameReservationInfoProps extends MakeReservationInfoProps {
@@ -32,7 +32,7 @@ export const useGameReservationStore = create<GameReservationStore>((set) => ({
     startTime: '',
     adultCount: 0,
     teenagerCount: 0,
-    kidCount: 0,
+    kidsCount: 0,
     askToManager: '',
     gameCount: 0,
   },
@@ -46,7 +46,7 @@ export const useTimeReservationStore = create<TimeReservationStore>((set) => ({
     endTime: '',
     adultCount: 0,
     teenagerCount: 0,
-    kidCount: 0,
+    kidsCount: 0,
     askToManager: '',
   },
   setTimeReservationInfo: (info) => set({ timeReservationInfo: info }),

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -6,7 +6,7 @@ export interface paymentFirstStageInfoProps {
   eventDate: string;
   adultCount: number;
   teenagerCount?: number;
-  kidCount?: number;
+  kidsCount?: number;
   eventStartTime: string;
   eventEndTime: string;
   stageFirstPrice: number;
@@ -25,7 +25,7 @@ export const usePaymentFirstStage = create<paymentFirstStageStore>((set) => ({
     eventDate: '',
     adultCount: 0,
     teenagerCount: 0,
-    kidCount: 0,
+    kidsCount: 0,
     eventStartTime: '',
     eventEndTime: '',
     stageFirstPrice: 0,

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -5,7 +5,7 @@ export interface paymentFirstStageInfoProps {
   companyAddress: string;
   eventDate: string;
   adultCount: number;
-  youngManCount?: number;
+  teenagerCount?: number;
   kidCount?: number;
   eventStartTime: string;
   eventEndTime: string;
@@ -24,7 +24,7 @@ export const usePaymentFirstStage = create<paymentFirstStageStore>((set) => ({
     companyAddress: '',
     eventDate: '',
     adultCount: 0,
-    youngManCount: 0,
+    teenagerCount: 0,
     kidCount: 0,
     eventStartTime: '',
     eventEndTime: '',

--- a/src/store/searchInfoStore.ts
+++ b/src/store/searchInfoStore.ts
@@ -6,7 +6,7 @@ interface SearchInputProps {
   searchDate: string;
   adultCount: number;
   teenagerCount: number;
-  kidCount: number;
+  kidsCount: number;
 }
 
 interface Store {
@@ -20,7 +20,7 @@ export const useSearchInputInfo = create<Store>((set) => ({
     searchDate: formatDate(new Date(), 'yyyy-MM-dd'),
     adultCount: 1,
     teenagerCount: 0,
-    kidCount: 0,
+    kidsCount: 0,
   },
   setSearchInput: (status: SearchInputProps) => set({ searchInput: status }),
 }));

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -6,7 +6,7 @@ export interface HistoryInProgressItemProps {
   eventStartTime: string;
   eventEndTime: string;
   adultCount?: number;
-  youngManCount?: number;
+  teenagerCount?: number;
   kidCount?: number;
   reservationStatus: 'inProgress' | 'confirmed';
   reservationId: number;

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -7,7 +7,7 @@ export interface HistoryInProgressItemProps {
   eventEndTime: string;
   adultCount?: number;
   teenagerCount?: number;
-  kidCount?: number;
+  kidsCount?: number;
   reservationStatus: 'inProgress' | 'confirmed';
   reservationId: number;
 }

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -8,7 +8,13 @@ export interface HistoryInProgressItemProps {
   adultCount?: number;
   teenagerCount?: number;
   kidsCount?: number;
-  reservationStatus: 'inProgress' | 'confirmed';
+  reservationStatus:
+    | 'CONFIRMED'
+    | 'TBC'
+    | 'DECLINED'
+    | 'CANCELED'
+    | 'DONE'
+    | 'REVIEWED';
   reservationId: number;
 }
 
@@ -20,12 +26,31 @@ export interface HistoryComponentUpperSectionProps
   className?: string;
 }
 
-export interface HistoryEndItemProps
-  extends Omit<HistoryInProgressItemProps, 'reservationStatus'> {
-  closedReservationStatus:
-    | 'alreadyReviewed'
-    | 'notYetReviewed'
-    | 'canceled'
-    | 'denied';
+export interface HistoryEndItemProps extends HistoryInProgressItemProps {
   reviewId?: number;
+}
+
+// Omit<HistoryInProgressItemProps, 'reservationStatus'> {
+//   closedReservationStatus:
+//     | 'alreadyReviewed'
+//     | 'notYetReviewed'
+//     | 'canceled'
+//     | 'denied';
+
+export interface ReservationItemProps {
+  adultCount: number;
+  teenagerCount: number;
+  kidsCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  price: number;
+  // 아래의 속성은 각각 예약 확정, 예약 진행중, 거절됨, 취소됨, 체험 완료됨(리뷰는 아직), 체험 완료됨(리뷰도 끝남)을 의미
+  status: 'CONFIRMED' | 'TBC' | 'DECLINED' | 'CANCELED' | 'DONE' | 'REVIEWED';
+  memberId: number;
+  clubId: number;
+  type: any; // any로 된 것은 추후 수정
+  businessHours: any;
+  clubName: any;
+  clubAddress: any;
 }

--- a/src/types/reservation-list/reservation/ReservationDetailType.ts
+++ b/src/types/reservation-list/reservation/ReservationDetailType.ts
@@ -6,7 +6,7 @@ export interface ReservationDetailProps {
   eventStartTime: string;
   eventEndTime: string;
   adultCount?: number;
-  youngManCount?: number;
+  teenagerCount?: number;
   kidCount?: number;
   reservationNumber: string;
   reservationUserName: string;

--- a/src/types/reservation-list/reservation/ReservationDetailType.ts
+++ b/src/types/reservation-list/reservation/ReservationDetailType.ts
@@ -7,7 +7,7 @@ export interface ReservationDetailProps {
   eventEndTime: string;
   adultCount?: number;
   teenagerCount?: number;
-  kidCount?: number;
+  kidsCount?: number;
   reservationNumber: string;
   reservationUserName: string;
   phoneNumber: string;

--- a/src/types/reservation-list/review/ReservationListReviewPageTypes.ts
+++ b/src/types/reservation-list/review/ReservationListReviewPageTypes.ts
@@ -10,7 +10,7 @@ export interface ReviewLowerSectionProps {
   reservationUserName: string;
   eventDate: string;
   adultCount?: number;
-  youngManCount?: number;
+  teenagerCount?: number;
   kidCount?: number;
   rating: number;
   rateContent: string;

--- a/src/types/reservation-list/review/ReservationListReviewPageTypes.ts
+++ b/src/types/reservation-list/review/ReservationListReviewPageTypes.ts
@@ -11,7 +11,7 @@ export interface ReviewLowerSectionProps {
   eventDate: string;
   adultCount?: number;
   teenagerCount?: number;
-  kidCount?: number;
+  kidsCount?: number;
   rating: number;
   rateContent: string;
   className?: string;


### PR DESCRIPTION
백엔드에서 던져주는 mock data와 연결

```
reservationStatus:
    | 'CONFIRMED'
    | 'TBC'
    | 'DECLINED'
    | 'CANCELED'
    | 'DONE'
    | 'REVIEWED';
```
위의 방식으로 예약의 진행상황을 구별하며 각각 확정됨, 예약 진행중, 거절됨, 스스로 취소함, 체험 완료됨(리뷰는 아직), 체험 완료됨(리뷰도 완료)의 상태를 가짐. 
추후에 백엔드에서 다른 예약 상세 조회, 리뷰 쓰기 페이지로 이동하기 위한 값을 전달해주시기로 함