### PR TITLE
Fix/wishlistlayout

### DIFF
--- a/src/app/(NavBarCommonLayout)/wishlist/page.tsx
+++ b/src/app/(NavBarCommonLayout)/wishlist/page.tsx
@@ -8,6 +8,7 @@ import ResultCard from '@components/search/result/ResultCard';
 import { useEffect, useState } from 'react';
 import useTab from '@store/tabNumberStore';
 import { useGetWishList } from '@apis/wishlist/getWishList';
+import NoneResultUI from '@components/all/NoneResultUI/NoneResultUI';
 
 export default function Page() {
   const selectedTab = useTab((state) => state.selectedTab);
@@ -19,6 +20,8 @@ export default function Page() {
     return <div>Error: {error.message}</div>;
   }
 
+  console.log(selectedTab);
+
   return (
     <div className="flex flex-col h-full pb-[54px] items-center">
       <NoneArrowHeader title="위시리스트" />
@@ -29,46 +32,60 @@ export default function Page() {
         className="w-fit px-5 top-[68px] border-b-[1px] border-grey2"
       />
 
-      {selectedTab === '전체' && (
-        <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
-          {data ? (
-            data?.result?.length > 0 ? (
-              data.result.map((data) => <ResultCard key={data.id} {...data} />)
-            ) : (
-              <div className="flex w-full justify-center pt-5 title2 text-grey7">
-                위시리스트가 비어 있습니다.
-              </div>
-            )
+      {selectedTab === '전체' &&
+        (data ? (
+          data?.result.length > 0 ? (
+            <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
+              {data.result.map((wishListData) => (
+                <ResultCard key={wishListData.id} {...wishListData} />
+              ))}
+            </main>
           ) : (
-            <div className="flex w-full justify-center pt-5 title2 text-grey7">
-              로딩중
+            <div className="flex w-full h-full justify-center items-center pt-[120px]  title2 text-grey7">
+              <NoneResultUI
+                message="위시리스트에 담긴 곳이 없어요"
+                subMessage="마음에 드는 장소를 찾아 담아보세요!"
+              />
             </div>
-          )}
-        </main>
-      )}
+          )
+        ) : (
+          <div className="flex w-full h-full justify-center items-center pt-[120px]  title2 text-grey7">
+            <NoneResultUI
+              message="로딩 중입니다."
+              subMessage="조금만 기다려주세요!!"
+            />
+          </div>
+        ))}
 
-      {selectedTab !== '전체' && (
-        <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
-          {data ? (
-            data?.result?.length > 0 ? (
-              data.result
+      {selectedTab !== '전체' &&
+        (data ? (
+          data?.result.length > 0 ? (
+            <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
+              {data.result
                 .filter((wishListItem) => {
                   const mappedCategory = categoryMapKorToEng[selectedTab];
                   return wishListItem.category === mappedCategory;
                 })
-                .map((data) => <ResultCard key={data.id} {...data} />)
-            ) : (
-              <div className="flex w-full justify-center pt-5 title2 text-grey7">
-                위시리스트가 비어 있습니다.
-              </div>
-            )
+                .map((wishListData) => (
+                  <ResultCard key={wishListData.id} {...wishListData} />
+                ))}
+            </main>
           ) : (
-            <div className="flex w-full justify-center pt-5 title2 text-grey7">
-              로딩중
+            <div className="flex w-full h-full justify-center items-center pt-[120px]  title2 text-grey7">
+              <NoneResultUI
+                message="위시리스트에 담긴 곳이 없어요"
+                subMessage="마음에 드는 장소를 찾아 담아보세요!"
+              />
             </div>
-          )}
-        </main>
-      )}
+          )
+        ) : (
+          <div className="flex w-full h-full justify-center items-center pt-[120px]  title2 text-grey7">
+            <NoneResultUI
+              message="로딩 중입니다."
+              subMessage="조금만 기다려주세요!!"
+            />
+          </div>
+        ))}
 
       {/* <NavBar /> */}
     </div>

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -45,9 +45,9 @@ export default function HistoryComponentUpperSection({
           <div className="w-full h-fit flex justify-start items-center gap-x-[6px]">
             <SmallPersonSVG />
             <span className="body4 text-grey7">
-              {adultCount !== 0 && `성인 ${adultCount}명`}{' '}
-              {teenagerCount !== 0 && `청소년 ${teenagerCount}명`}{' '}
-              {kidsCount !== 0 && `어린이 ${kidsCount}명`}
+              {adultCount && `성인 ${adultCount}명`}{' '}
+              {teenagerCount && `청소년 ${teenagerCount}명`}{' '}
+              {kidsCount && `어린이 ${kidsCount}명`}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## 🕹️ 개요
현재 위시리스트에서 일단 검색 결과가 없거나 로딩 중인 경우 div로 처리하고 있는데, 이는 `NoneResult` 컴포넌트로 하면 더 좋다고 판단
## 🔎 작업 사항
1. NoneResult 컴포넌트를 활용하고 레이아웃 변경
2. HistoryUpperSection 컴포넌트에서 어른, 청소년, 아이의 count UI에 `undefined` 가 나타날 수 있기에 이를 수정

## 📋 작업 브랜치
