### PR TITLE
Feat/cancel reservation

### DIFF
--- a/src/apis/reservation-list/cancelUserReservation.ts
+++ b/src/apis/reservation-list/cancelUserReservation.ts
@@ -1,0 +1,2 @@
+import { instance } from '@apis/instance';
+import { useMutation } from '@tanstack/react-query';

--- a/src/apis/reservation-list/cancelUserReservation.ts
+++ b/src/apis/reservation-list/cancelUserReservation.ts
@@ -1,2 +1,14 @@
 import { instance } from '@apis/instance';
 import { useMutation } from '@tanstack/react-query';
+import { NoMeaningfulResultResponse } from 'types/response/response';
+
+export const cancelUserReservationFunc = (reservationId: number) => {
+  return instance.post(`/api/v1/reservation/cancel/${reservationId}`);
+};
+
+// 우선 예약 취소는 중요한 사안이라 낙관적 업데이트를 적용하지 않는 것으로
+export const useCancelUserReservation = (reservationId: number) => {
+  return useMutation({
+    mutationFn: () => cancelUserReservationFunc(reservationId),
+  });
+};

--- a/src/apis/reservation-list/getUserReservationList.ts
+++ b/src/apis/reservation-list/getUserReservationList.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
+import { instance } from '@apis/instance';
 
 export interface userReservationListResponse {
   result: ReservationItemProps[];
@@ -9,20 +10,21 @@ export interface userReservationListResponse {
 
 export const getUserReservationList =
   async (): Promise<userReservationListResponse> => {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/all`,
-      {
-        credentials: 'include',
-      }
-    );
+    // const response = await fetch(
+    //   `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/all`,
+    //   {
+    //     credentials: 'include',
+    //   }
+    // );
 
-    if (!response.ok) {
-      throw new Error('Failed to fetch user reservation list data!');
-    }
+    // if (!response.ok) {
+    //   throw new Error('Failed to fetch user reservation list data!');
+    // }
 
-    const data: userReservationListResponse = await response.json();
+    // const data: userReservationListResponse = await response.json();
 
-    return data;
+    // return data;
+    return instance.get('/api/v1/resevation/all');
   };
 
 export const useGetReservationList = () => {

--- a/src/apis/reservation-list/reservation/deleteUserSpecificReservation.ts
+++ b/src/apis/reservation-list/reservation/deleteUserSpecificReservation.ts
@@ -1,15 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
+import { NoMeaningfulResultResponse } from 'types/response/response';
 import { error } from 'console';
-
-export interface deleteUserSpecificReservationResponse {
-  result: Record<string, never>; // {} 로 응답이 오므로, 빈 객체를 명시하는 방식
-  resultCode: number;
-  resultMsg: string;
-}
 
 export const deleteUserSpecificReservation = async (
   reservationId: number
-): Promise<deleteUserSpecificReservationResponse> => {
+): Promise<NoMeaningfulResultResponse> => {
   // api 엔드포인트는 추후 restful하게 수정 예정임
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/vi/reservation/cancel/${reservationId}`,

--- a/src/apis/wishlist/deleteFromWishlist.ts
+++ b/src/apis/wishlist/deleteFromWishlist.ts
@@ -1,11 +1,11 @@
 import { instance } from '@apis/instance';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { NoneMeaningfulResultResponse } from 'types/response/response';
+import { NoMeaningfulResultResponse } from 'types/response/response';
 import { ResultCardProps } from 'types/search/result/searchResult';
 
 export const deleteFromWishList = async (
   clubId: number
-): Promise<NoneMeaningfulResultResponse> => {
+): Promise<NoMeaningfulResultResponse> => {
   return instance.delete(`/api/v1/wishlist/${clubId}`);
 };
 

--- a/src/apis/wishlist/deleteFromWishlist.ts
+++ b/src/apis/wishlist/deleteFromWishlist.ts
@@ -1,11 +1,11 @@
 import { instance } from '@apis/instance';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { DeleteFromWishListResponse } from 'types/response/response';
+import { NoneMeaningfulResultResponse } from 'types/response/response';
 import { ResultCardProps } from 'types/search/result/searchResult';
 
 export const deleteFromWishList = async (
   clubId: number
-): Promise<DeleteFromWishListResponse> => {
+): Promise<NoneMeaningfulResultResponse> => {
   return instance.delete(`/api/v1/wishlist/${clubId}`);
 };
 
@@ -18,7 +18,11 @@ export const useDeleteFromWishList = () => {
       await queryClient.cancelQueries({ queryKey: ['wishlist'] });
 
       // 먼저 해당 아이템의 업데이트 이전 정보를 저장
-      const prevWishlist = queryClient.getQueryData<{ result: ResultCardProps[]; resultCode: number; resultMsg: string }>(['wishlist']);
+      const prevWishlist = queryClient.getQueryData<{
+        result: ResultCardProps[];
+        resultCode: number;
+        resultMsg: string;
+      }>(['wishlist']);
 
       if (!prevWishlist) {
         return { prevWishlist: { result: [] } };
@@ -26,7 +30,7 @@ export const useDeleteFromWishList = () => {
       // 새로운 선택지 데이터로 낙관적 업데이트 실시
       const newOption = {
         ...prevWishlist,
-        result: prevWishlist.result.filter(item => item.id !== clubId),
+        result: prevWishlist.result.filter((item) => item.id !== clubId),
       };
       queryClient.setQueryData(['wishlist'], newOption);
 

--- a/src/apis/writing-review/postReview.ts
+++ b/src/apis/writing-review/postReview.ts
@@ -1,17 +1,12 @@
 import { reviewInfoProps } from '@apis/reservation-list/review/getSpecificReviewInfo';
 import { useMutation } from '@tanstack/react-query';
-
-export interface postReviewResponse {
-  result: Record<string, never>;
-  resultCode: number;
-  resultMsg: string;
-}
+import { NoMeaningfulResultResponse } from 'types/response/response';
 
 export const postReview = async (
   reservationId: number,
   rating: number,
   contents: string
-): Promise<postReviewResponse> => {
+): Promise<NoMeaningfulResultResponse> => {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/vi/review/${reservationId}`,
     {

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -37,7 +37,7 @@ export interface PostHomeResponse {
   resultMsg: string;
 }
 
-export interface NoneMeaningfulResultResponse {
+export interface NoMeaningfulResultResponse {
   result: Record<string, never>;
   resultCode: number;
   resultMsg: string;

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -37,7 +37,7 @@ export interface PostHomeResponse {
   resultMsg: string;
 }
 
-export interface DeleteFromWishListResponse {
+export interface NoneMeaningfulResultResponse {
   result: Record<string, never>;
   resultCode: number;
   resultMsg: string;


### PR DESCRIPTION
## 🕹️ 개요

## 🔎 작업 사항
1. /reservation-list 페이지에서 사용자의 예약 데이터를 가져오는 custom hook에 axios instance 적용
2. 여러 api들에서 요청을 보내면 빈 result 속성과 resultCode, resultMsg를 응답으로 반환하는 경우가 많이 나타나는데, 이를 `noMeaningfulResultResponse`라는 타입으로 만들고 관련 코드에 적용
3. 예약을 취소하는 api를 생성 -> `/api/reservation/deleteUserSpecificReservation` 디렉터리에 생성(예약 취소는 wishlist 지우는 것과는 다르게 중요한 포인트이므로 일단 낙관적 업데이트를 적용하지 않음) 

## 📋 작업 브랜치
