### PR TITLE
Refactor/writing review

### DIFF
--- a/src/apis/detail-page/getAllClubReview.ts
+++ b/src/apis/detail-page/getAllClubReview.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { reviewInfoProps } from '@apis/reservation-list/review/getSpecificReviewInfo';
+import { instance } from '@apis/instance';
 
 export interface getAllClubReviewResponse {
   result: reviewInfoProps[];
@@ -10,16 +11,7 @@ export interface getAllClubReviewResponse {
 export const getAllClubReview = async (
   clubId: number
 ): Promise<getAllClubReviewResponse> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/review/club/${clubId}`
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch review data of club ${clubId}`);
-  }
-
-  const data = await response.json();
-  return data;
+  return instance.get(`/api/v1/review/club/${clubId}`);
 };
 
 export const useGetAllClubReview = (clubId: number) => {

--- a/src/apis/reservation-list/getUserReservationList.ts
+++ b/src/apis/reservation-list/getUserReservationList.ts
@@ -10,20 +10,6 @@ export interface userReservationListResponse {
 
 export const getUserReservationList =
   async (): Promise<userReservationListResponse> => {
-    // const response = await fetch(
-    //   `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/all`,
-    //   {
-    //     credentials: 'include',
-    //   }
-    // );
-
-    // if (!response.ok) {
-    //   throw new Error('Failed to fetch user reservation list data!');
-    // }
-
-    // const data: userReservationListResponse = await response.json();
-
-    // return data;
     return instance.get('/api/v1/reservation/all');
   };
 

--- a/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
+++ b/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
@@ -11,7 +11,7 @@ export interface userSpecificReservationInfoResponse {
 
 export const getUserSpecificReservationInfo = async (
   reservationId: number
-): Promise<userSpecificReservationInfoResponse | noDataServerErrorResponse> => {
+): Promise<userSpecificReservationInfoResponse & noDataServerErrorResponse> => {
   return instance.get(`/api/v1/reservation/${reservationId}`);
 };
 

--- a/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
+++ b/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
+import { instance } from '@apis/instance';
+import { noDataServerErrorResponse } from 'types/response/response';
 
 export interface userSpecificReservationInfoResponse {
   result: ReservationItemProps;
@@ -9,22 +11,8 @@ export interface userSpecificReservationInfoResponse {
 
 export const getUserSpecificReservationInfo = async (
   reservationId: number
-): Promise<userSpecificReservationInfoResponse> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/${reservationId}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  if (!response.ok) {
-    // 추후에 네트워크 오류로 못 가져온 것인지, 인가되지 않은 사용자의 접근인지를 구분해주어야 한다
-    throw new Error("Failed to fetch user's specific reservation information");
-  }
-
-  const data = await response.json();
-
-  return data;
+): Promise<userSpecificReservationInfoResponse | noDataServerErrorResponse> => {
+  return instance.get(`/api/v1/reservation/${reservationId}`);
 };
 
 export const useGetUserSpecificReservationInfo = (reservationId: number) => {

--- a/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
+++ b/src/apis/reservation-list/reservation/getUserSpecificReservationInfo.ts
@@ -11,7 +11,7 @@ export interface userSpecificReservationInfoResponse {
 
 export const getUserSpecificReservationInfo = async (
   reservationId: number
-): Promise<userSpecificReservationInfoResponse & noDataServerErrorResponse> => {
+): Promise<userSpecificReservationInfoResponse> => {
   return instance.get(`/api/v1/reservation/${reservationId}`);
 };
 

--- a/src/apis/reservation-list/review/getSpecificReviewInfo.ts
+++ b/src/apis/reservation-list/review/getSpecificReviewInfo.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
+import { instance } from '@apis/instance';
 
 export interface reviewInfoProps {
   reservationId: number;
@@ -19,20 +20,7 @@ export interface specifiReviewInfoResponse {
 export const getSpecificReviewInfo = async (
   reviewId: number
 ): Promise<specifiReviewInfoResponse> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/review/${reviewId}`,
-    {
-      credentials: 'include',
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch specific review information');
-  }
-
-  const data = await response.json();
-
-  return data;
+  return instance.get(`/api/v1/review/${reviewId}`);
 };
 
 export const useGetSpecificReviewInfo = (reviewId: number) => {

--- a/src/apis/writing-review/postReview.ts
+++ b/src/apis/writing-review/postReview.ts
@@ -1,39 +1,19 @@
 import { reviewInfoProps } from '@apis/reservation-list/review/getSpecificReviewInfo';
 import { useMutation } from '@tanstack/react-query';
 import { NoMeaningfulResultResponse } from 'types/response/response';
+import { instance } from '@apis/instance';
 
 export const postReview = async (
-  reservationId: number,
-  rating: number,
-  contents: string
+  postReviewData: reviewInfoProps
 ): Promise<NoMeaningfulResultResponse> => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/vi/review/${reservationId}`,
-    {
-      credentials: 'include',
-      body: JSON.stringify({
-        reservationId,
-        rating,
-        contents,
-      }),
-    }
+  return instance.post(
+    `/api/v1/review/${postReviewData.reservationId}`,
+    postReviewData
   );
-
-  if (!response.ok) {
-    throw new Error(`Failed to post review to reservation ${reservationId}`);
-  }
-
-  const data = await response.json();
-
-  return data;
 };
 
-export const usePostReview = (
-  reservationId: number,
-  rating: number,
-  contents: string
-) => {
+export const usePostReview = () => {
   return useMutation({
-    mutationFn: () => postReview(reservationId, rating, contents),
+    mutationFn: postReview,
   });
 };

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useState, useEffect } from 'react';
-import NavBar from '@components/all/NavBar/NavBar';
 import HistoryHead from '@components/reservation-list/HistoryHead';
 import HistoryInProgressItem from '@components/reservation-list/HistoryInProgressItem';
 import HistoryEndItem from '@components/reservation-list/HistoryEndItem';
@@ -1250,7 +1249,6 @@ export default function Page() {
         title="예약을 취소하시겠습니까?"
         subTitle="예약 취소 시 수수료가 발생할 수 있습니다"
       />
-      {/* <NavBar /> */}
     </div>
   );
 }

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -38,7 +38,7 @@ export default function Page({
   const [isReviewSubmitted, setIsReviewSubmitted] = useState(false);
   const router = useRouter();
 
-  const { data, isFetching } = useGetUserSpecificReservationInfo(
+  const { data, isError } = useGetUserSpecificReservationInfo(
     params.reservationId
   );
 
@@ -48,10 +48,10 @@ export default function Page({
   const [reviewContents, setReviewContents] = useState<string>('');
 
   useEffect(() => {
-    if (data?.status === 500) {
+    if (isError === true) {
       router.replace('/');
     }
-  }, [data]);
+  }, [isError]);
 
   useEffect(() => {
     return () => {
@@ -60,8 +60,8 @@ export default function Page({
   }, []);
   return (
     <>
-      {data?.resultCode === undefined && <TigLoadingPage />}
-      {data && !isReviewSubmitted && !isFetching && data?.status !== 500 && (
+      {!isError && !data && <TigLoadingPage />}
+      {data && !isReviewSubmitted && !isError && (
         <div className="w-full flex flex-col items-center h-full bg-grey1">
           <Header
             buttonType="close"

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -12,6 +12,9 @@ import { useState, useEffect } from 'react';
 import useModal from '@store/modalStore';
 import FortyEightTig from '@public/svg/fortyEightTig.svg';
 import ReviewLowerSection from '@components/reservation-list/review/ReviewLowerSection';
+import { useGetUserSpecificReservationInfo } from '@apis/reservation-list/reservation/getUserSpecificReservationInfo';
+import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
+import { instance } from '@apis/instance';
 
 const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
   clubName: '스카이락볼링장',
@@ -22,12 +25,24 @@ const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
   adultCount: 8,
 };
 
-export default function Page() {
+export default function Page({
+  params,
+}: {
+  params: {
+    reservationId: number;
+  };
+}) {
   const setIsSelectedModalOpen = useModal(
     (state) => state.setSelectedIsModalOpen
   );
   const [isReviewSubmitted, setIsReviewSubmitted] = useState(false);
   const router = useRouter();
+
+  const { data, isError, isSuccess, isPending, status, isFetching, isLoading } =
+    useGetUserSpecificReservationInfo(params.reservationId);
+
+  // 현재 response로 돌아오는 응답에 result 속성이 없어서 resultMsg로 비교할 수 밖에 없음. undefined로 하면 첫 렌더링 시에 없기에 null과의 차별점을 두지 못함
+  useEffect(() => {}, []);
 
   useEffect(() => {
     return () => {
@@ -49,7 +64,7 @@ export default function Page() {
               <HistoryComponentUpperSection
                 className="bg-white"
                 imageUrl={DUMMYREVIEWDATA.imageUrl}
-                clubAddress={DUMMYREVIEWDATA.clubName}
+                clubAddress={DUMMYREVIEWDATA.clubAddress}
                 clubName={DUMMYREVIEWDATA.clubName}
                 eventDate={DUMMYREVIEWDATA.eventDate}
                 eventEndTime={DUMMYREVIEWDATA.eventEndTime}

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -37,14 +37,17 @@ export default function Page({
   const [isReviewSubmitted, setIsReviewSubmitted] = useState(false);
   const router = useRouter();
 
-  const { data, isError, isSuccess, isPending, status, isFetching, isLoading } =
-    useGetUserSpecificReservationInfo(params.reservationId);
+  const { data, isFetching } = useGetUserSpecificReservationInfo(
+    params.reservationId
+  );
 
   useEffect(() => {
     if (data?.status === 500) {
       router.replace('/');
     }
   }, [data]);
+
+  console.log(data?.result);
 
   useEffect(() => {
     return () => {
@@ -54,7 +57,7 @@ export default function Page({
   return (
     <>
       {data?.resultCode === undefined && <TigLoadingPage />}
-      {!isReviewSubmitted && !isFetching && data?.status !== 500 && (
+      {data && !isReviewSubmitted && !isFetching && data?.status !== 500 && (
         <div className="w-full flex flex-col items-center h-full bg-grey1">
           <Header
             buttonType="close"
@@ -67,14 +70,14 @@ export default function Page({
               <HistoryComponentUpperSection
                 className="bg-white"
                 imageUrl={DUMMYREVIEWDATA.imageUrl}
-                clubAddress={DUMMYREVIEWDATA.clubAddress}
-                clubName={DUMMYREVIEWDATA.clubName}
-                eventDate={DUMMYREVIEWDATA.eventDate}
-                eventEndTime={DUMMYREVIEWDATA.eventEndTime}
-                eventStartTime={DUMMYREVIEWDATA.eventStartTime}
-                adultCount={DUMMYREVIEWDATA.adultCount}
-                teenagerCount={DUMMYREVIEWDATA.teenagerCount}
-                kidsCount={DUMMYREVIEWDATA.kidsCount}
+                clubAddress={data.result.clubAddress}
+                clubName={data.result.clubName}
+                eventDate={data.result.date}
+                eventEndTime={data.result.endTime}
+                eventStartTime={data.result.startTime}
+                adultCount={data.result.adultCount}
+                teenagerCount={data.result.teenagerCount}
+                kidsCount={data.result.kidsCount}
               />
             </div>
             <div className="w-full h-fit rounded-[10px] bg-white py-5 px-[110px] flex flex-col gap-y-[10px] items-center">

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -41,13 +41,14 @@ export default function Page({
     params.reservationId
   );
 
+  const [starCount, setStarCount] = useState<number>(0);
+  const [reviewContents, setReviewContents] = useState<string>('');
+
   useEffect(() => {
     if (data?.status === 500) {
       router.replace('/');
     }
   }, [data]);
-
-  console.log(data?.result);
 
   useEffect(() => {
     return () => {
@@ -83,11 +84,19 @@ export default function Page({
             <div className="w-full h-fit rounded-[10px] bg-white py-5 px-[110px] flex flex-col gap-y-[10px] items-center">
               <span className="title4 text-grey7">평점을 선택해주세요</span>
               <p className="flex justify-between items-end">
-                <WritingReviewFilledStarSVG />
-                <WritingReviewUnfilledStarSVG />
-                <WritingReviewUnfilledStarSVG />
-                <WritingReviewUnfilledStarSVG />
-                <WritingReviewUnfilledStarSVG />
+                {[1, 2, 3, 4, 5].map((num) =>
+                  num > starCount ? (
+                    <WritingReviewUnfilledStarSVG
+                      key={num}
+                      onClick={() => setStarCount(num)}
+                    />
+                  ) : (
+                    <WritingReviewFilledStarSVG
+                      key={num}
+                      onClick={() => setStarCount(num)}
+                    />
+                  )
+                )}
               </p>
             </div>
             <div className="w-full h-fit grow rounded-[10px] p-5 flex flex-col items-center gap-y-5 bg-white">
@@ -106,6 +115,8 @@ export default function Page({
               <textarea
                 className="w-sevenEightWidth p-4 rounded-[10px] grow text-black caption3 placeholder:text-grey3 placeholder:caption3 shadow-writingReviewInput focus:outline-none"
                 placeholder="이용하신 시설에 대해 자세한 리뷰를 남겨주세요"
+                value={reviewContents}
+                onChange={(ev) => setReviewContents(ev.target.value)}
               />
             </div>
           </div>

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -41,8 +41,9 @@ export default function Page({
   const { data, isError, isSuccess, isPending, status, isFetching, isLoading } =
     useGetUserSpecificReservationInfo(params.reservationId);
 
-  // 현재 response로 돌아오는 응답에 result 속성이 없어서 resultMsg로 비교할 수 밖에 없음. undefined로 하면 첫 렌더링 시에 없기에 null과의 차별점을 두지 못함
-  useEffect(() => {}, []);
+  if (isPending === false && data?.status === 500) {
+    router.replace('/');
+  }
 
   useEffect(() => {
     return () => {

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -13,8 +13,7 @@ import useModal from '@store/modalStore';
 import FortyEightTig from '@public/svg/fortyEightTig.svg';
 import ReviewLowerSection from '@components/reservation-list/review/ReviewLowerSection';
 import { useGetUserSpecificReservationInfo } from '@apis/reservation-list/reservation/getUserSpecificReservationInfo';
-import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
-import { instance } from '@apis/instance';
+import TigLoadingPage from '@components/all/TigLoadingPage';
 
 const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
   clubName: '스카이락볼링장',
@@ -41,9 +40,11 @@ export default function Page({
   const { data, isError, isSuccess, isPending, status, isFetching, isLoading } =
     useGetUserSpecificReservationInfo(params.reservationId);
 
-  if (isPending === false && data?.status === 500) {
-    router.replace('/');
-  }
+  useEffect(() => {
+    if (data?.status === 500) {
+      router.replace('/');
+    }
+  }, [data]);
 
   useEffect(() => {
     return () => {
@@ -52,7 +53,8 @@ export default function Page({
   }, []);
   return (
     <>
-      {!isReviewSubmitted && (
+      {data?.resultCode === undefined && <TigLoadingPage />}
+      {!isReviewSubmitted && !isFetching && data?.status !== 500 && (
         <div className="w-full flex flex-col items-center h-full bg-grey1">
           <Header
             buttonType="close"

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -190,10 +190,12 @@ export default function Page({
               <div className="w-full border-b-[1px] border-grey2" />
               <ReviewLowerSection
                 reservationUserName="김티그"
-                eventDate="2024.05.05"
-                adultCount={8}
-                rating={4}
-                rateContent="역 근처에 시설도 깔끔하고 좋아요! 신촌 볼링장 하면 꼭 여기로 가요. 직원분들도 친절하고 레일도 많고 최고! 담에 친구들이랑 단체 모임하면 또 갈게요~!"
+                eventDate={data.result.date.replace(/-/g, '.')}
+                adultCount={data.result.adultCount}
+                teenagerCount={data.result.teenagerCount}
+                kidsCount={data.result.kidsCount}
+                rating={starCount}
+                rateContent={reviewContents}
               />
             </section>
           </main>

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -14,6 +14,7 @@ import FortyEightTig from '@public/svg/fortyEightTig.svg';
 import ReviewLowerSection from '@components/reservation-list/review/ReviewLowerSection';
 import { useGetUserSpecificReservationInfo } from '@apis/reservation-list/reservation/getUserSpecificReservationInfo';
 import TigLoadingPage from '@components/all/TigLoadingPage';
+import { usePostReview } from '@apis/writing-review/postReview';
 
 const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
   clubName: '스카이락볼링장',
@@ -40,6 +41,8 @@ export default function Page({
   const { data, isFetching } = useGetUserSpecificReservationInfo(
     params.reservationId
   );
+
+  const mutation = usePostReview();
 
   const [starCount, setStarCount] = useState<number>(0);
   const [reviewContents, setReviewContents] = useState<string>('');
@@ -126,7 +129,23 @@ export default function Page({
             bgColor="black"
             content="작성 완료"
             className="writingReviewButton relative bottom-[30px]"
-            onClick={() => setIsReviewSubmitted(true)} // 해당 로직에서 백엔드로 전송을 하고 성공하면 그떄 상태를 변경시키는 것이 최종 목적임
+            onClick={() => {
+              mutation.mutate(
+                {
+                  reservationId: params.reservationId,
+                  rating: starCount,
+                  contents: reviewContents,
+                },
+                {
+                  onSuccess: () => {
+                    setIsReviewSubmitted(true);
+                  },
+                  onError: () => {
+                    alert('리뷰 작성이 실패했습니다! 다시 시도해보세요');
+                  },
+                }
+              );
+            }} // 해당 로직에서 백엔드로 전송을 하고 성공하면 그떄 상태를 변경시키는 것이 최종 목적임
           />
           <Modal
             size="lg"
@@ -138,7 +157,7 @@ export default function Page({
           />
         </div>
       )}
-      {isReviewSubmitted && (
+      {data && isReviewSubmitted && (
         <div className="w-full flex flex-col items-center h-full bg-grey1">
           <Header
             buttonType="close"
@@ -159,14 +178,14 @@ export default function Page({
               <HistoryComponentUpperSection
                 className="bg-white"
                 imageUrl={DUMMYREVIEWDATA.imageUrl}
-                clubAddress={DUMMYREVIEWDATA.clubAddress}
-                clubName={DUMMYREVIEWDATA.clubName}
-                eventDate={DUMMYREVIEWDATA.eventDate}
-                eventEndTime={DUMMYREVIEWDATA.eventEndTime}
-                eventStartTime={DUMMYREVIEWDATA.eventStartTime}
-                adultCount={DUMMYREVIEWDATA.adultCount}
-                teenagerCount={DUMMYREVIEWDATA.teenagerCount}
-                kidsCount={DUMMYREVIEWDATA.kidsCount}
+                clubAddress={data.result.clubAddress}
+                clubName={data.result.clubName}
+                eventDate={data.result.date}
+                eventEndTime={data.result.endTime}
+                eventStartTime={data.result.startTime}
+                adultCount={data.result.adultCount}
+                teenagerCount={data.result.teenagerCount}
+                kidsCount={data.result.kidsCount}
               />
               <div className="w-full border-b-[1px] border-grey2" />
               <ReviewLowerSection

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -44,7 +44,7 @@ export default function HistoryComponentUpperSection({
           </div>
           <div className="w-full h-fit flex justify-start items-center gap-x-[6px]">
             <SmallPersonSVG />
-            <span className="body4 text-grey7">
+            <span className="body4 text-grey7 txt-overflow-ellipsis">
               {adultCount && `성인 ${adultCount}명`}{' '}
               {teenagerCount && `청소년 ${teenagerCount}명`}{' '}
               {kidsCount && `어린이 ${kidsCount}명`}

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -54,4 +54,5 @@ export interface ReservationItemProps {
   clubName: string;
   clubAddress: string;
   reservationId: number | null;
+  memberName?: string;
 }

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -57,3 +57,12 @@ export interface UserInfoResponse {
   resultCode: number;
   resultMsg: string;
 }
+
+// 현재 백엔드에서 response로 보내주는 실제로는 200 statusCode이지만 실패를 의미하는 응답 인터페이스
+export interface noDataServerErrorResponse {
+  status: number;
+  divisionCode: string;
+  resultMsg: string;
+  errors: any;
+  reason: string; // 못 찾은 이유를 백엔드에서 보내줌
+}

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -60,7 +60,7 @@ export interface UserInfoResponse {
 
 // 현재 백엔드에서 response로 보내주는 실제로는 200 statusCode이지만 실패를 의미하는 응답 인터페이스
 export interface noDataServerErrorResponse {
-  status: number;
+  status: 500;
   divisionCode: string;
   resultMsg: string;
   errors: any;


### PR DESCRIPTION
## 🕹️ 개요

## 🔎 작업 사항
1. 서버에서 없는 데이터로 접근할 때의 response에 status 값으로 500이 오는데, 이는 착시임. 실제로 네트워크 요청은 200으로 뜸. 우리가 분기쳐서 해야됨. 따라서 `noDataServerErrorResponse`라는 타입을 만들어줬음
2. 아직 `fetch()` 함수를 쓰고 있는 로직들에 axios instance 적용시켜줬음
3. 처음 /writing-review 페이지에 접근하는 사용자들에게 잠시 loading UI 띄워주고, 없는 reservationId에 접근하는 사용자는 다시 홈페이지로 튕겨줬음 -> url로 접근하는 미친놈들 제거
4. reservationId로 받아온 데이터를 `HistoryUpperSection` 컴포넌트에 적용해줌
5. 별점과 컨텐츠를 useState 상태로 관리. 별점도 클릭하면 변화하게 만듬
6. 리뷰 작성 후 버튼 클릭하면 백엔드 api로 요청 보내지고 리뷰 작성 완료 페이지 변화하게 UI 렌더링 해줌. `mutate()`의 onSuccess 속성 활용

