### PR TITLE
Feat/payment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tig-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@portone/browser-sdk": "^0.0.8",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.51.1",
         "@types/crypto-js": "^4.2.2",
@@ -2741,6 +2742,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@portone/browser-sdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@portone/browser-sdk/-/browser-sdk-0.0.8.tgz",
+      "integrity": "sha512-OPejBEDy5IhsGo4bGq9wtoulkPPg5ahKM/3/WL4E1sii3dwNQpFf3F0mEw3pau6XLm8/1khJZ44aJZheKBYKlQ=="
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.51.1",
+        "@types/crypto-js": "^4.2.2",
         "@types/react-modal": "^3.16.3",
         "axios": "^1.7.2",
         "clsx": "^2.1.1",
+        "crypto-js": "^4.2.0",
         "date-fns": "^3.6.0",
         "framer-motion": "^11.2.12",
         "lottie-react": "^2.4.0",
@@ -3089,6 +3091,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
@@ -4005,6 +4012,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-select": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "type": "module",
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.51.1",
+    "@types/crypto-js": "^4.2.2",
     "@types/react-modal": "^3.16.3",
     "axios": "^1.7.2",
     "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.2.12",
     "lottie-react": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "start": "next start",
     "lint": "next lint"
   },
-  "type": "module",
   "dependencies": {
+    "@portone/browser-sdk": "^0.0.8",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.51.1",
     "@types/crypto-js": "^4.2.2",

--- a/src/apis/portone/inicisPay.ts
+++ b/src/apis/portone/inicisPay.ts
@@ -9,12 +9,13 @@ const handleInicisPay = async (memberId: number, currentDateString: string) => {
     orderName: '나이키 와플 트레이너 2 SD',
     totalAmount: 1000, // 이니시스는 1000원 미만 결제 안됨
     currency: 'CURRENCY_KRW',
-    payMethod: 'VIRTUAL_ACCOUNT',
+    payMethod: 'CARD',
     customer: {
       fullName: '포트원',
       phoneNumber: '010-0000-1234',
       email: 'test@portone.io',
     },
+    redirectUrl: 'https://localhost/payment/redirect',
   });
 
   console.log(response);

--- a/src/apis/portone/inicisPay.ts
+++ b/src/apis/portone/inicisPay.ts
@@ -1,0 +1,23 @@
+import * as PortOne from '@portone/browser-sdk/v2';
+import makePaymentId from '@utils/makePaymentId';
+
+const handleInicisPay = async (memberId: number, currentDateString: string) => {
+  const response = await PortOne.requestPayment({
+    storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
+    channelKey: process.env.NEXT_PUBLIC_PORTONE_INICIS_CHANNEL_KEY,
+    paymentId: makePaymentId(memberId, currentDateString),
+    orderName: '나이키 와플 트레이너 2 SD',
+    totalAmount: 1000, // 이니시스는 1000원 미만 결제 안됨
+    currency: 'CURRENCY_KRW',
+    payMethod: 'VIRTUAL_ACCOUNT',
+    customer: {
+      fullName: '포트원',
+      phoneNumber: '010-0000-1234',
+      email: 'test@portone.io',
+    },
+  });
+
+  console.log(response);
+};
+
+export default handleInicisPay;

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -1,0 +1,21 @@
+import * as PortOne from '@portone/browser-sdk/v2';
+import makePaymentId from '@utils/makePaymentId';
+
+const handleKakaokEasyPay = async (
+  memberId: number,
+  currentDateString: string
+) => {
+  const response = await PortOne.requestPayment({
+    storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
+    channelKey: process.env.NEXT_PUBLIC_PORTONE_KAKAO_EASY_PAY_CHANNEL_KEY,
+    paymentId: makePaymentId(memberId, currentDateString),
+    orderName: '나이키 와플 트레이너 2 SD',
+    totalAmount: 100,
+    currency: 'CURRENCY_KRW',
+    payMethod: 'EASY_PAY',
+  });
+
+  console.log(response);
+};
+
+export default handleKakaokEasyPay;

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -13,6 +13,7 @@ const handleKakaokEasyPay = async (
     totalAmount: 100,
     currency: 'CURRENCY_KRW',
     payMethod: 'EASY_PAY',
+    redirectUrl: 'https://localhost/payment/redirect',
   });
 
   console.log(response);

--- a/src/apis/portone/paycoEasyPay.ts
+++ b/src/apis/portone/paycoEasyPay.ts
@@ -1,0 +1,21 @@
+import * as PortOne from '@portone/browser-sdk/v2';
+import makePaymentId from '@utils/makePaymentId';
+
+const handlePaycoEasyPay = async (
+  memberId: number,
+  currentDateString: string
+) => {
+  const response = await PortOne.requestPayment({
+    storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
+    channelKey: process.env.NEXT_PUBLIC_PORTONE_PAYCO_EASY_PAY_CHANNEL_KEY,
+    paymentId: makePaymentId(memberId, currentDateString),
+    orderName: '나이키 와플 트레이너 2 SD',
+    totalAmount: 100,
+    currency: 'CURRENCY_KRW',
+    payMethod: 'CARD',
+  });
+
+  console.log(response);
+};
+
+export default handlePaycoEasyPay;

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -1,0 +1,21 @@
+import * as PortOne from '@portone/browser-sdk/v2';
+import makePaymentId from '@utils/makePaymentId';
+
+const handleTossEasyPay = async (
+  memberId: number,
+  currentDateString: string
+) => {
+  const response = await PortOne.requestPayment({
+    storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
+    channelKey: process.env.NEXT_PUBLIC_PORTONE_TOSS_EASY_PAY_CHANNEL_KEY,
+    paymentId: makePaymentId(memberId, currentDateString),
+    orderName: '나이키 와플 트레이너 2 SD',
+    totalAmount: 100,
+    currency: 'CURRENCY_KRW',
+    payMethod: 'CARD',
+  });
+
+  console.log(response);
+};
+
+export default handleTossEasyPay;

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -13,6 +13,7 @@ const handleTossEasyPay = async (
     totalAmount: 100,
     currency: 'CURRENCY_KRW',
     payMethod: 'CARD',
+    redirectUrl: 'https://localhost/payment/redirect',
   });
 
   console.log(response);

--- a/src/app/payment/redirect/page.tsx
+++ b/src/app/payment/redirect/page.tsx
@@ -1,0 +1,10 @@
+// 해당 페이지는 결제를 하고 모바일 환경에서 redirect 되는 상황을 위해 존재
+
+export default function PaymentRedirect({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  console.log(searchParams);
+  return <div>This is redirect page</div>;
+}

--- a/src/app/test-payment/page.tsx
+++ b/src/app/test-payment/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+import handleKakaokEasyPay from '@apis/portone/kakaoEasyPay';
+import handleTossEasyPay from '@apis/portone/tossEasyPay';
+import handlePaycoEasyPay from '@apis/portone/paycoEasyPay';
+import handleInicisPay from '@apis/portone/inicisPay';
+
+export default function TestPayment() {
+  return (
+    <div className="w-full flex justify-evenly items-center">
+      <button
+        className="w-20 h-20 bg-yellow-500"
+        onClick={() => handleKakaokEasyPay(1, new Date().toISOString())}
+      >
+        This is kakao easy pay button
+      </button>
+      <button
+        className="w-20 h-20 bg-blue-600"
+        onClick={() => handleTossEasyPay(1, new Date().toISOString())}
+      >
+        This is toss easy pay button
+      </button>
+      <button
+        className="w-20 h-20 bg-red-600"
+        onClick={() => handlePaycoEasyPay(1, new Date().toISOString())}
+      >
+        This is payco easy pay button
+      </button>
+      <button
+        className="w-20 h-20 bg-green-600"
+        onClick={() => handleInicisPay(1, new Date().toISOString())}
+      >
+        This is Inicis easy pay button
+      </button>
+    </div>
+  );
+}

--- a/src/utils/makePaymentId.ts
+++ b/src/utils/makePaymentId.ts
@@ -1,0 +1,10 @@
+import CryptoJS from 'crypto-js';
+
+export default function makePaymentId(
+  memberId: number,
+  currentDateString: string
+): string {
+  return CryptoJS.MD5(`${memberId}${currentDateString}`).toString(
+    CryptoJS.enc.Hex
+  );
+}


### PR DESCRIPTION
## 🕹️ 개요
portOne 결제 관련 유틸 함수 작성

## 🔎 작업 사항
1. 환경변수를 추가해야됨(카톡으로 보내줄게)
2. api 디렉터리의 payment 폴더에 카카오, 토스, 페이코, 이니시스 관련 함수 작성 -> 페이코는 공식문서도 없고 안됨. 네이버페이는 실제로 사업자 등록해야 확인해볼 수 있는듯
3. 모바일 환경일 시, redirect_uri로 paymentId, transactionType, txId 쿼리 파라미터로 제대로 도착하는거 확인함. 모바일에선 이거, pc 환경에서는 response에서 paymentId 백엔드로 쏴주면 될듯
4. paymentId를 만들어주는 유틸 함수를 만들었음. 원래는 bcryptjs 함수를 쓰려고 했는데, paymentId는 40자 제한이 있음. 근데 bcrypt는 60 자로 토큰이 반환됨. 그래서 다른 라이브러리 깔고 md5인가 하는 알고리즘으로 만들어줌

## 📋 작업 브랜치
