### PR TITLE
[Fix] : navBar에서 localStorageAccessToken을 처음 마운트될 때 설정되는 상태로 선언

### DIFF
--- a/src/components/all/NavBar/NavItem.tsx
+++ b/src/components/all/NavBar/NavItem.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { type NavItemType } from 'types/all/NavTypes';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function NavItem({
   ActiveIcon,
@@ -10,10 +10,13 @@ export default function NavItem({
   path,
 }: NavItemType) {
   const pathname: string | null = usePathname();
-  let localStorageAccessToken: string | null = null;
+
+  const [localStorageAccessToken, setLocalStorageAccessToken] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
-    localStorageAccessToken = localStorage.getItem('accessToken');
+    setLocalStorageAccessToken(localStorage.getItem('accessToken'));
   }, []);
 
   const targetPath =


### PR DESCRIPTION
## 🕹️ 개요
기존에 navBar에서 가장 마지막 사람 아이콘을 눌렀을 때, 로그인이 된 상태이더라도 잠깐 /login 화면이 보이는 문제가 있었는데 해결

## 🔎 작업 사항
1. 원래는 이걸 그냥 변수로 관리해주고 초깃값을 null로 줬어서 링크가 /login으로 걸렸있었고, 로컬 스토리지에 accessToken이 있더라도 거기로 갔다가 튕겨지는 느낌이었음
2. 그냥 상태로 만들어서 navBar가 있는 레이아웃이 mount될 때 값을 갸져와서 상태로 가져옴
3. 사실 가장 엣지케이스는 사용자가 localStorage에서 accessToken을 직접 지울때임. 이때에는 사람이 인위적으로 지워준 것이라 상태가 연동되어서 바뀌지 못함. 그래도 지우고 각각 /login, /mypage로 가면 또 로컬스토리지 검사를 하기 때문에 잘 튕겨지긴 함.
4. 3에서의 문제는 나중에 `accessToken`을 로컬 스토리지에서 전역상태로 바꿔주면 사라짐

## 📋 작업 브랜치
