### PR TITLE
결제 관련 수정 사항

### DIFF
--- a/src/apis/club/getSpecificClubInfo.ts
+++ b/src/apis/club/getSpecificClubInfo.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { instance } from '@apis/instance';
+
+interface clubInfoProps {
+  id: number;
+  clubName: string;
+  address: string;
+  ratingSum: number;
+  ratingCount: number;
+  avgRating: number;
+  price: number;
+  phonenumber: string;
+  snsLink: string;
+  businessHour: string;
+  latitude: number;
+  longitude: number;
+  category: string;
+  type: 'GAME' | 'TIME';
+  imageUrls: string[];
+  presignedImageUrls: string[];
+}
+
+interface SpecificClubInfoResponse {
+  result: clubInfoProps;
+  resultCode: number;
+  resultMsg: string;
+}
+
+export const getSpecificClubInfo = async (
+  clubId: number
+): Promise<SpecificClubInfoResponse> => {
+  return instance.get(`/api/v1/club/${clubId}`);
+};
+
+export const useGetSpecificClubInfo = (clubId: number) => {
+  return useQuery({
+    queryKey: ['specificClubInfo', clubId],
+    queryFn: () => getSpecificClubInfo(clubId),
+  });
+};

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -24,21 +24,24 @@ instance.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
-  },
+  }
 );
+
+interface ReissueResponse {
+  result: {
+    accessToken: string;
+  };
+  resultCode: number;
+  resultMsg: string;
+}
 
 const regainAccessToken = async (): Promise<string | void> => {
   try {
-    const {
-      // 리프레시 토큰은 쿠키로 담김
-      data: { accessToken },
-    } = await axios.get<{ accessToken: string;}>(
-      REFRESH_URL,
-    );
+    const data = await instance.post<ReissueResponse>(REFRESH_URL);
+    console.log(data);
+    localStorage.setItem('accessToken', data.result.accessToken);
 
-    localStorage.setItem('accessToken', accessToken);
-
-    return accessToken;
+    return data.result.accessToken;
   } catch (e) {
     localStorage.removeItem('accessToken');
   }
@@ -63,9 +66,8 @@ instance.interceptors.response.use(
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
-    
+
     // 새로운 토큰으로 재요청
     return instance(config);
-  },
+  }
 );
-

--- a/src/apis/payment/before/postReservation.ts
+++ b/src/apis/payment/before/postReservation.ts
@@ -7,7 +7,8 @@ interface reservationRequestBodyProp {
   kidsCount: number;
   date: string;
   startTime: string;
-  endTime: string;
+  endTime?: string;
+  gameCount?: number;
   price: number;
   status: 'TBC';
   clubId: number;

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -1,8 +1,6 @@
 import { instance } from '@apis/instance';
 import * as PortOne from '@portone/browser-sdk/v2';
-import makePaymentId from '@utils/makePaymentId';
 import { calculateTimeDiff } from '@utils/formatDate';
-import { AxiosResponse } from 'axios';
 
 export interface kakaoEasyPayBackendResponse {
   result: {

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -4,7 +4,19 @@ import makePaymentId from '@utils/makePaymentId';
 const handleKakaokEasyPay = async (
   memberId: number,
   currentDateString: string,
-  paymentPrice: number
+  paymentPrice: number,
+  reservationData: {
+    clubId: number;
+    date: string;
+    startTime: string;
+    endTime?: string;
+    gameCount?: number;
+    adultCount: number;
+    teenagerCount: number;
+    kidsCount: number;
+    userName: string;
+    memberId: number;
+  }
 ) => {
   const response = await PortOne.requestPayment({
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
@@ -15,6 +27,18 @@ const handleKakaokEasyPay = async (
     currency: 'CURRENCY_KRW',
     payMethod: 'EASY_PAY',
     redirectUrl: 'https://localhost/payment/redirect',
+    customData: {
+      clubId: reservationData.clubId,
+      date: reservationData.date,
+      startTime: reservationData.startTime,
+      endTime: reservationData.endTime,
+      gameCount: reservationData.gameCount,
+      adultCount: reservationData.adultCount,
+      teenagerCount: reservationData.teenagerCount,
+      kidsCount: reservationData.kidsCount,
+      userName: reservationData.userName,
+      memberId: reservationData.memberId,
+    },
   });
 
   console.log(response);

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -27,6 +27,31 @@ const handleKakaokEasyPay = async (
     memberId: number;
   }
 ): Promise<kakaoEasyPayBackendResponse> => {
+  // redirect로 보낼 query string임
+  const query = {
+    clubId: reservationData.clubId.toString(),
+    date: reservationData.date,
+    startTime: reservationData.startTime,
+    endTime: reservationData.endTime ? reservationData.endTime : '',
+    gameCount: reservationData.gameCount
+      ? reservationData.gameCount.toString()
+      : '',
+    adultCount: reservationData.adultCount.toString(),
+    teenagerCount: reservationData.teenagerCount.toString(),
+    kidsCount: reservationData.kidsCount.toString(),
+    paymentId: customPaymentId,
+    clubPrice: (
+      paymentPrice /
+      calculateTimeDiff(
+        reservationData.endTime as string,
+        reservationData.startTime
+      )
+    ).toString(),
+    paymentPrice: paymentPrice.toString(),
+  };
+
+  const queryString = new URLSearchParams(query).toString();
+
   const response = await PortOne.requestPayment({
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
     channelKey: process.env.NEXT_PUBLIC_PORTONE_KAKAO_EASY_PAY_CHANNEL_KEY,
@@ -35,7 +60,7 @@ const handleKakaokEasyPay = async (
     totalAmount: paymentPrice,
     currency: 'CURRENCY_KRW',
     payMethod: 'EASY_PAY',
-    redirectUrl: 'https://localhost/payment/redirect',
+    redirectUrl: `${process.env.NEXT_PUBLIC_FRONTEND_DOMAIN}/payment/redirect?${queryString}`,
     customData: {
       clubId: reservationData.clubId,
       date: reservationData.date,

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -2,8 +2,9 @@ import { instance } from '@apis/instance';
 import * as PortOne from '@portone/browser-sdk/v2';
 import makePaymentId from '@utils/makePaymentId';
 import { calculateTimeDiff } from '@utils/formatDate';
+import { AxiosResponse } from 'axios';
 
-interface kakaoEasyPayBackendResponse {
+export interface kakaoEasyPayBackendResponse {
   result: {
     resultMsg: string;
     resultCode: number;
@@ -13,8 +14,7 @@ interface kakaoEasyPayBackendResponse {
 }
 
 const handleKakaokEasyPay = async (
-  memberId: number,
-  currentDateString: string,
+  customPaymentId: string,
   paymentPrice: number,
   reservationData: {
     clubId: number;
@@ -28,8 +28,7 @@ const handleKakaokEasyPay = async (
     userName: string;
     memberId: number;
   }
-) => {
-  const customPaymentId = makePaymentId(memberId, currentDateString);
+): Promise<kakaoEasyPayBackendResponse> => {
   const response = await PortOne.requestPayment({
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
     channelKey: process.env.NEXT_PUBLIC_PORTONE_KAKAO_EASY_PAY_CHANNEL_KEY,
@@ -53,7 +52,7 @@ const handleKakaokEasyPay = async (
     },
   });
 
-  const result = await instance.post(
+  const result: kakaoEasyPayBackendResponse = await instance.post(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,
     {
       adultCount: reservationData.adultCount,
@@ -74,7 +73,6 @@ const handleKakaokEasyPay = async (
       paymentPrice: paymentPrice,
     }
   );
-
   return result;
 };
 

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -3,9 +3,17 @@ import makePaymentId from '@utils/makePaymentId';
 import { instance } from '@apis/instance';
 import { calculateTimeDiff } from '@utils/formatDate';
 
+export interface tossEasyPayBackendResponse {
+  result: {
+    resultMsg: string;
+    resultCode: number;
+  } | null;
+  resultCode: number;
+  resultMsg: string;
+}
+
 const handleTossEasyPay = async (
-  memberId: number,
-  currentDateString: string,
+  customPaymentId: string,
   paymentPrice: number,
   reservationData: {
     clubId: number;
@@ -19,11 +27,11 @@ const handleTossEasyPay = async (
     userName: string;
     memberId: number;
   }
-) => {
+): Promise<tossEasyPayBackendResponse> => {
   const response = await PortOne.requestPayment({
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
     channelKey: process.env.NEXT_PUBLIC_PORTONE_TOSS_EASY_PAY_CHANNEL_KEY,
-    paymentId: makePaymentId(memberId, currentDateString),
+    paymentId: customPaymentId,
     orderName: '나이키 와플 트레이너 2 SD',
     totalAmount: paymentPrice,
     currency: 'CURRENCY_KRW',
@@ -43,7 +51,7 @@ const handleTossEasyPay = async (
     },
   });
 
-  const result = await instance.post(
+  const result: tossEasyPayBackendResponse = await instance.post(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,
     {
       adultCount: reservationData.adultCount,

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -4,7 +4,19 @@ import makePaymentId from '@utils/makePaymentId';
 const handleTossEasyPay = async (
   memberId: number,
   currentDateString: string,
-  paymentPrice: number
+  paymentPrice: number,
+  reservationData: {
+    clubId: number;
+    date: string;
+    startTime: string;
+    endTime?: string;
+    gameCount?: number;
+    adultCount: number;
+    teenagerCount: number;
+    kidsCount: number;
+    userName: string;
+    memberId: number;
+  }
 ) => {
   const response = await PortOne.requestPayment({
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
@@ -15,6 +27,18 @@ const handleTossEasyPay = async (
     currency: 'CURRENCY_KRW',
     payMethod: 'CARD',
     redirectUrl: 'https://localhost/payment/redirect',
+    customData: {
+      clubId: reservationData.clubId,
+      date: reservationData.date,
+      startTime: reservationData.startTime,
+      endTime: reservationData.endTime,
+      gameCount: reservationData.gameCount,
+      adultCount: reservationData.adultCount,
+      teenagerCount: reservationData.teenagerCount,
+      kidsCount: reservationData.kidsCount,
+      userName: reservationData.userName,
+      memberId: reservationData.memberId,
+    },
   });
 
   console.log(response);

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -1,5 +1,7 @@
 import * as PortOne from '@portone/browser-sdk/v2';
 import makePaymentId from '@utils/makePaymentId';
+import { instance } from '@apis/instance';
+import { calculateTimeDiff } from '@utils/formatDate';
 
 const handleTossEasyPay = async (
   memberId: number,
@@ -41,7 +43,29 @@ const handleTossEasyPay = async (
     },
   });
 
-  console.log(response);
+  const result = await instance.post(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,
+    {
+      adultCount: reservationData.adultCount,
+      teenagerCount: reservationData.teenagerCount,
+      kidsCount: reservationData.kidsCount,
+      date: reservationData.date,
+      startTime: reservationData.startTime,
+      endTime: reservationData.endTime,
+      gameCount: reservationData.gameCount,
+      clubPrice:
+        paymentPrice /
+        calculateTimeDiff(
+          reservationData.endTime as string,
+          reservationData.startTime
+        ),
+      clubId: reservationData.clubId,
+      paymentId: response?.paymentId,
+      paymentPrice: paymentPrice,
+    }
+  );
+
+  return result;
 };
 
 export default handleTossEasyPay;

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -23,20 +23,27 @@ export default function Page() {
     '전체' | '진행중' | '종료된'
   >('전체');
   const [reservationList, setReservationList] = useState<
-    ReservationItemProps[]
+    ReservationItemProps[] | []
   >([]);
+
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [cancelPaymentId, setCancelPaymentId] = useState<string | null>(null);
 
-  const inProgressReservationList = reservationList.filter(
-    (reservationItem) =>
-      reservationItem.status === 'CONFIRMED' || reservationItem.status === 'TBC'
-  );
+  const inProgressReservationList = reservationList
+    ? reservationList.filter(
+        (reservationItem) =>
+          reservationItem.status === 'CONFIRMED' ||
+          reservationItem.status === 'TBC'
+      )
+    : [];
 
-  const endReservationList = reservationList.filter(
-    (reservationItem) =>
-      reservationItem.status !== 'CONFIRMED' && reservationItem.status !== 'TBC'
-  );
+  const endReservationList = reservationList
+    ? reservationList.filter(
+        (reservationItem) =>
+          reservationItem.status !== 'CONFIRMED' &&
+          reservationItem.status !== 'TBC'
+      )
+    : [];
 
   const setSelectedIsModalOpen = useModal(
     (state) => state.setSelectedIsModalOpen
@@ -73,7 +80,13 @@ export default function Page() {
 
   useEffect(() => {
     if (data) {
-      setReservationList(data.result);
+      // 데이터가 없는 경우에는 result 필드가 null로 오기 때문에 아래에서 문제가 생기는 상황이 발생함
+      if (data.result === null) {
+        setReservationList([]);
+      } else {
+        setReservationList(data.result);
+      }
+
       setIsLoading(false);
     }
     // data의 resultCode가 오류이면 여기에서도 setIsLoading(false)로 바꾸고 reservationList는 빈 것으로 유지
@@ -86,7 +99,7 @@ export default function Page() {
 
   return (
     <>
-      {isLoading ? (
+      {isLoading || !reservationList ? (
         <TigLoadingPage />
       ) : (
         <div className="flex flex-col h-full pb-[54px] items-center">

--- a/src/app/(NavBarCommonLayout)/wishlist/page.tsx
+++ b/src/app/(NavBarCommonLayout)/wishlist/page.tsx
@@ -12,9 +12,12 @@ import NoneResultUI from '@components/all/NoneResultUI/NoneResultUI';
 import Lottie from 'lottie-react';
 import TigLoadingAnimation from '@public/lottie/TigLoadingAnimation.json';
 import { addToWishList, useAddToWishList } from '@apis/wishlist/addToWishList';
+import { WishListResponse, wishListItemProps } from 'types/response/response';
+import { da } from 'date-fns/locale';
 
 export default function Page() {
   const selectedTab = useTab((state) => state.selectedTab);
+  const [wishList, setWishList] = useState<ResultCardProps[]>([]);
   const { data, isError, error, isSuccess } = useGetWishList();
   const mutation = useAddToWishList();
 
@@ -28,6 +31,16 @@ export default function Page() {
   //   mutation.mutate(15);
   //   mutation.mutate(16);
   // }, []);
+
+  useEffect(() => {
+    if (data) {
+      if (data.result === null) {
+        return; // 기존의 []로 계속 감
+      } else {
+        setWishList(data.result);
+      }
+    }
+  }, [data]);
 
   if (isError) {
     return <div>Error: {error.message}</div>;
@@ -45,9 +58,9 @@ export default function Page() {
 
       {selectedTab === '전체' &&
         (isSuccess ? (
-          data?.result.length > 0 ? (
+          wishList.length > 0 ? (
             <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
-              {data.result.map((wishListData) => (
+              {wishList.map((wishListData) => (
                 <ResultCard key={wishListData.id} {...wishListData} isHeart />
               ))}
             </main>
@@ -70,9 +83,9 @@ export default function Page() {
 
       {selectedTab !== '전체' &&
         (isSuccess ? (
-          data?.result.length > 0 ? (
+          wishList.length > 0 ? (
             <main className="w-full max-h-wishListMain absolute top-[120px] pb-10 overflow-y-scroll">
-              {data.result
+              {wishList
                 .filter((wishListItem) => {
                   const mappedCategory = categoryMapKorToEng[selectedTab];
                   return wishListItem.category === mappedCategory;

--- a/src/app/payment/after/[reservationId]/page.tsx
+++ b/src/app/payment/after/[reservationId]/page.tsx
@@ -2,11 +2,17 @@ import Header from '@components/all/Header';
 import PaymentAfterConfirm from '@components/payment/after/PaymentAfterConfirm';
 import FullButton from '@components/all/FullButton';
 
-export default function page() {
+export default function page({
+  params,
+}: {
+  params: {
+    reservationId: string;
+  };
+}) {
   return (
     <main className="w-full h-full flex flex-col items-center bg-grey1 pb-[100px] overflow-y-scroll">
       <Header buttonType="close" isCenter title="예약 결제" bgColor="grey" />
-      <PaymentAfterConfirm />
+      <PaymentAfterConfirm reservationId={params.reservationId} />
       <FullButton
         size="lg"
         color="white"

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -28,8 +28,8 @@ interface searchParamsProps {
   kidsCount: string | undefined;
   date: string | undefined;
   startTime: string | undefined;
-  endTime: string | undefined;
-  gameCount: string | undefined;
+  endTime?: string | undefined;
+  gameCount?: number | undefined;
   clubName: string | undefined;
   clubAddress: string | undefined;
   gameType: string | undefined;
@@ -113,9 +113,10 @@ export default function Page({
               reservationSearchParmasObject.startTime as string
             )
           : reservationSearchParmasObject.gameType === 'GAME' &&
-            clubSpecificInfoResponse.data.result.type === 'GAME'
+            clubSpecificInfoResponse.data.result.type === 'GAME' &&
+            reservationSearchParmasObject.gameCount
           ? clubSpecificInfoResponse.data?.result.price *
-            parseInt(reservationSearchParmasObject.gameCount as string)
+            reservationSearchParmasObject.gameCount
           : 0
         : 0,
     };
@@ -143,9 +144,10 @@ export default function Page({
                 reservationSearchParmasObject.startTime as string
               )
             : reservationSearchParmasObject.gameType === 'GAME' &&
-              clubSpecificInfoResponse.data.result.type === 'GAME'
+              clubSpecificInfoResponse.data.result.type === 'GAME' &&
+              reservationSearchParmasObject.gameCount
             ? clubSpecificInfoResponse.data?.result.price *
-              parseInt(reservationSearchParmasObject.gameCount as string)
+              reservationSearchParmasObject.gameCount
             : 0
           : 0,
         paymentMethod: null,
@@ -218,6 +220,12 @@ export default function Page({
               secondStageInfoObject.couponDiscountPrice
             ).toLocaleString()}원 결제하기`}
             clickTask="request-payment"
+            sendingData={{
+              reservationData: {
+                clubId: parseInt(params.clubId),
+                memberId: userInfoResponse.data?.result.id as number,
+              },
+            }}
           />
         </section>
       )}

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -31,6 +31,7 @@ interface searchParamsProps {
   clubName: string | undefined;
   clubAddress: string | undefined;
   gameType: string | undefined;
+  clubId: string | undefined;
 }
 
 export default function Page({

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -19,6 +19,7 @@ import useModal from '@store/modalStore';
 import { Toaster } from 'react-hot-toast';
 import { useGetUserInfo } from '@apis/mypage/getUserInfo';
 import { useGetSpecificClubInfo } from '@apis/club/getSpecificClubInfo';
+import { calculateTimeDiff } from '@utils/formatDate';
 
 interface searchParamsProps {
   adultCount: string | undefined;
@@ -103,8 +104,12 @@ export default function Page({
       clubAddress: reservationSearchParmasObject.clubAddress
         ? reservationSearchParmasObject.clubAddress
         : '',
-      price: reservationSearchParmasObject.price
-        ? parseInt(reservationSearchParmasObject.price)
+      price: clubSpecificInfoResponse.data?.result.price
+        ? clubSpecificInfoResponse.data?.result.price *
+          calculateTimeDiff(
+            reservationSearchParmasObject.endTime as string,
+            reservationSearchParmasObject.startTime as string
+          )
         : 0,
     };
 
@@ -122,8 +127,12 @@ export default function Page({
         userName: userInfoResponse.data.result.name,
         phoneNumber: userInfoResponse.data.result.phoneNumber,
         couponDiscountPrice: 0,
-        price: reservationSearchParmasObject.price
-          ? parseInt(reservationSearchParmasObject.price)
+        price: clubSpecificInfoResponse.data?.result.price
+          ? clubSpecificInfoResponse.data?.result.price *
+            calculateTimeDiff(
+              reservationSearchParmasObject.endTime as string,
+              reservationSearchParmasObject.startTime as string
+            )
           : 0,
         paymentMethod: null,
       };

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -104,12 +104,16 @@ export default function Page({
       clubAddress: reservationSearchParmasObject.clubAddress
         ? reservationSearchParmasObject.clubAddress
         : '',
+      // TIME 타입이면 종료시간 - 시작 시간을 빼서 가격과 곱하고, GAME 타입이면 게임 카운트를 가격에 곱해 계산
       price: clubSpecificInfoResponse.data?.result.price
-        ? clubSpecificInfoResponse.data?.result.price *
-          calculateTimeDiff(
-            reservationSearchParmasObject.endTime as string,
-            reservationSearchParmasObject.startTime as string
-          )
+        ? reservationSearchParmasObject.gameType == 'TIME'
+          ? clubSpecificInfoResponse.data?.result.price *
+            calculateTimeDiff(
+              reservationSearchParmasObject.endTime as string,
+              reservationSearchParmasObject.startTime as string
+            )
+          : clubSpecificInfoResponse.data?.result.price *
+            parseInt(reservationSearchParmasObject.gameCount as string)
         : 0,
     };
 
@@ -128,11 +132,14 @@ export default function Page({
         phoneNumber: userInfoResponse.data.result.phoneNumber,
         couponDiscountPrice: 0,
         price: clubSpecificInfoResponse.data?.result.price
-          ? clubSpecificInfoResponse.data?.result.price *
-            calculateTimeDiff(
-              reservationSearchParmasObject.endTime as string,
-              reservationSearchParmasObject.startTime as string
-            )
+          ? reservationSearchParmasObject.gameType == 'TIME'
+            ? clubSpecificInfoResponse.data?.result.price *
+              calculateTimeDiff(
+                reservationSearchParmasObject.endTime as string,
+                reservationSearchParmasObject.startTime as string
+              )
+            : clubSpecificInfoResponse.data?.result.price *
+              parseInt(reservationSearchParmasObject.gameCount as string)
           : 0,
         paymentMethod: null,
       };

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -18,20 +18,19 @@ import Modal from '@components/all/Modal';
 import useModal from '@store/modalStore';
 import { Toaster } from 'react-hot-toast';
 import { useGetUserInfo } from '@apis/mypage/getUserInfo';
+import { useGetSpecificClubInfo } from '@apis/club/getSpecificClubInfo';
 
 interface searchParamsProps {
   adultCount: string | undefined;
   teenagerCount: string | undefined;
   kidsCount: string | undefined;
   date: string | undefined;
-  price: string | undefined;
   startTime: string | undefined;
   endTime: string | undefined;
   gameCount: string | undefined;
   clubName: string | undefined;
   clubAddress: string | undefined;
   gameType: string | undefined;
-  clubId: string | undefined;
 }
 
 export default function Page({
@@ -41,6 +40,7 @@ export default function Page({
   params: { clubId: string };
   searchParams: searchParamsProps;
 }) {
+  console.log(searchParams);
   const reservationStageState = useReservationStage(
     (state) => state.reservationStage
   );
@@ -68,9 +68,13 @@ export default function Page({
     (state) => state.setSelectedIsModalOpen
   );
 
-  const { data, isError } = useGetUserInfo();
+  const userInfoResponse = useGetUserInfo();
+  const clubSpecificInfoResponse = useGetSpecificClubInfo(
+    parseInt(params.clubId)
+  );
 
-  const clubId = params.clubId;
+  console.log(clubSpecificInfoResponse.data);
+
   const reservationSearchParmasObject = searchParams;
 
   useEffect(() => {
@@ -113,10 +117,10 @@ export default function Page({
       price: 0,
       paymentMethod: null,
     };
-    if (data !== undefined) {
+    if (userInfoResponse.data !== undefined) {
       secondStageObjData = {
-        userName: data.result.name,
-        phoneNumber: data.result.phoneNumber,
+        userName: userInfoResponse.data.result.name,
+        phoneNumber: userInfoResponse.data.result.phoneNumber,
         couponDiscountPrice: 0,
         price: reservationSearchParmasObject.price
           ? parseInt(reservationSearchParmasObject.price)
@@ -125,7 +129,7 @@ export default function Page({
       };
     }
     setSecondStageInfoObject(secondStageObjData);
-  }, [data]);
+  }, [userInfoResponse.data, clubSpecificInfoResponse.data]);
 
   useEffect(() => {
     return () => setSelectedIsModalOpen(false);

--- a/src/app/reservation/game/[companyId]/page.tsx
+++ b/src/app/reservation/game/[companyId]/page.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect } from 'react';
 import Header from '@components/all/Header';
 import MakeResButtonCard from '@components/reservation/MakeResButtonCard';
 import RequestCard from '@components/reservation/RequestCard';
@@ -5,11 +8,19 @@ import ResDateCard from '@components/reservation/ResDateCard';
 import ResGameCard from '@components/reservation/ResGameCard';
 import ResPeopleCountCard from '@components/reservation/ResPeopleCountCard';
 import GameCountCard from '@components/reservation/GameCountCard';
-
-const DUMMYPRICE = '10,000';
+import {
+  useGameReservationStore,
+  gameReservationInfoInitialState,
+} from '@store/makeReservationInfo';
 
 export default function Page() {
-  
+  const setGameReservationInfo = useGameReservationStore(
+    (state) => state.setGameReservationInfo
+  );
+
+  useEffect(() => {
+    return () => setGameReservationInfo(gameReservationInfoInitialState);
+  }, []);
   return (
     <main className="w-full h-full overflow-y-scroll flex flex-col ">
       <Header buttonType="back" isCenter title="예약하기" />
@@ -20,5 +31,5 @@ export default function Page() {
       <RequestCard />
       <MakeResButtonCard />
     </main>
-  )
+  );
 }

--- a/src/app/reservation/time/[companyId]/page.tsx
+++ b/src/app/reservation/time/[companyId]/page.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect } from 'react';
 import Header from '@components/all/Header';
 import MakeResButtonCard from '@components/reservation/MakeResButtonCard';
 import RequestCard from '@components/reservation/RequestCard';
@@ -5,11 +8,22 @@ import ResDateCard from '@components/reservation/ResDateCard';
 import ResPeopleCountCard from '@components/reservation/ResPeopleCountCard';
 import ResReservationCard from '@components/reservation/ResReservationCard';
 import RestimeCard from '@components/reservation/RestimeCard';
+import {
+  timeReservationInfoInitialState,
+  useTimeReservationStore,
+} from '@store/makeReservationInfo';
 
 const DUMMYPRICE = '10,000';
 
 export default function Page() {
-  
+  const setTimeReservationInfo = useTimeReservationStore(
+    (state) => state.setTimeReservationInfo
+  );
+
+  useEffect(() => {
+    // 언마운트될 때 다시 초기화
+    return () => setTimeReservationInfo(timeReservationInfoInitialState);
+  }, []);
   return (
     <main className="w-full h-full overflow-y-scroll flex flex-col ">
       <Header buttonType="back" isCenter title="예약하기" />
@@ -19,5 +33,5 @@ export default function Page() {
       <RequestCard />
       <MakeResButtonCard />
     </main>
-  )
+  );
 }

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -16,6 +16,7 @@ import { ButtonMouseEvent } from 'types/all/FullButtonTypes';
 import handleKakaokEasyPay from '@apis/portone/kakaoEasyPay';
 import handleTossEasyPay from '@apis/portone/tossEasyPay';
 import { useGetUserInfo } from '@apis/mypage/getUserInfo';
+import { instance } from '@apis/instance';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -212,7 +213,10 @@ export default function FullButton({
             userName: secondStageInfoObject.userName,
             memberId: sendingData.reservationData.memberId,
           }
-        );
+        )
+          .then((response) => console.log(response))
+          .catch((error) => console.log(error))
+          .finally(() => console.log('over'));
       }
 
       if (
@@ -238,7 +242,10 @@ export default function FullButton({
             userName: secondStageInfoObject.userName,
             memberId: sendingData.reservationData.memberId,
           }
-        );
+        )
+          .then((response) => console.log(response))
+          .catch((error) => console.log(error))
+          .finally(() => console.log('over'));
       }
 
       // 백엔드 전송 로직

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -49,6 +49,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     reviewId?: number;
     reservationId?: number | null;
     selectedCouponPrice?: number;
+    reservationData?: {
+      clubId: number;
+      memberId: number;
+    };
   };
 }
 
@@ -185,24 +189,55 @@ export default function FullButton({
 
       // 이제 해당 정보를 백엔드로 전송하면 됨
 
-      if (secondStageInfoObject.paymentMethod === 'kakaoPayment' && data) {
+      if (
+        secondStageInfoObject.paymentMethod === 'kakaoPayment' &&
+        data &&
+        sendingData?.reservationData?.clubId &&
+        sendingData.reservationData.memberId
+      ) {
         handleKakaokEasyPay(
           data.result.id,
           new Date().toLocaleString(),
           secondStageInfoObject.price -
-            secondStageInfoObject.couponDiscountPrice
+            secondStageInfoObject.couponDiscountPrice,
+          {
+            clubId: sendingData?.reservationData?.clubId,
+            date: firstStageInfoObject.date,
+            startTime: firstStageInfoObject.startTime,
+            endTime: firstStageInfoObject.endTime,
+            gameCount: firstStageInfoObject.gameCount,
+            adultCount: firstStageInfoObject.adultCount,
+            teenagerCount: firstStageInfoObject.teenagerCount,
+            kidsCount: firstStageInfoObject.kidsCount,
+            userName: secondStageInfoObject.userName,
+            memberId: sendingData.reservationData.memberId,
+          }
         );
       }
 
       if (
         secondStageInfoObject.paymentMethod === 'tossAndCardPayment' &&
-        data
+        data &&
+        sendingData?.reservationData?.clubId &&
+        sendingData.reservationData.memberId
       ) {
         handleTossEasyPay(
           data.result.id,
           new Date().toLocaleString(),
           secondStageInfoObject.price -
-            secondStageInfoObject.couponDiscountPrice
+            secondStageInfoObject.couponDiscountPrice,
+          {
+            clubId: sendingData?.reservationData?.clubId,
+            date: firstStageInfoObject.date,
+            startTime: firstStageInfoObject.startTime,
+            endTime: firstStageInfoObject.endTime,
+            gameCount: firstStageInfoObject.gameCount,
+            adultCount: firstStageInfoObject.adultCount,
+            teenagerCount: firstStageInfoObject.teenagerCount,
+            kidsCount: firstStageInfoObject.kidsCount,
+            userName: secondStageInfoObject.userName,
+            memberId: sendingData.reservationData.memberId,
+          }
         );
       }
 

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -242,13 +242,14 @@ export default function FullButton({
                 },
                 {
                   onSuccess(data, variables, context) {
-                    console.log(data);
+                    router.replace(
+                      `/payment/after/${data.result.reservationId}`
+                    );
                   },
                 }
               );
             }
           })
-          .then((rs) => console.log(rs))
           .catch((error) => console.log(error))
           .finally(() => console.log('over'));
       }
@@ -259,9 +260,12 @@ export default function FullButton({
         sendingData?.reservationData?.clubId &&
         sendingData.reservationData.memberId
       ) {
-        handleTossEasyPay(
+        const customPaymentId = makePaymentId(
           data.result.id,
-          new Date().toLocaleString(),
+          new Date().toLocaleString()
+        );
+        handleTossEasyPay(
+          customPaymentId,
           secondStageInfoObject.price -
             secondStageInfoObject.couponDiscountPrice,
           {
@@ -277,7 +281,34 @@ export default function FullButton({
             memberId: sendingData.reservationData.memberId,
           }
         )
-          .then((response) => console.log(response))
+          .then((response) => {
+            if (response.resultCode === 200) {
+              postReservationMutation.mutate(
+                {
+                  adultCount: firstStageInfoObject.adultCount,
+                  teenagerCount: firstStageInfoObject.teenagerCount,
+                  kidsCount: firstStageInfoObject.kidsCount,
+                  date: firstStageInfoObject.date,
+                  startTime: firstStageInfoObject.startTime,
+                  endTime: firstStageInfoObject.endTime,
+                  gameCount: firstStageInfoObject.gameCount,
+                  price:
+                    secondStageInfoObject.price -
+                    secondStageInfoObject.couponDiscountPrice,
+                  status: 'TBC',
+                  clubId: sendingData.reservationData?.clubId as number,
+                  paymentId: customPaymentId,
+                },
+                {
+                  onSuccess(data, variables, context) {
+                    router.replace(
+                      `/payment/after/${data.result.reservationId}`
+                    );
+                  },
+                }
+              );
+            }
+          })
           .catch((error) => console.log(error))
           .finally(() => console.log('over'));
       }

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -1,14 +1,47 @@
 // 백엔드로부터 예약 확정 정보를 받아오는 것이면 그냥 클라이언트 컴포넌트가 되어도 상관 없음
-'use client';
 import FortyEightTigSVG from '@public/svg/fortyEightTig.svg';
 // 하지만 사용자가 새로고침하면 전역 상태라고 하더라도 사라지기 때문에 백엔드로부터 받아오는 것이 더 맞지 않나싶음. 아니면 zustand persists
-import { usePaymentFirstStage } from '@store/paymentInfoStore';
 import HistoryComponentUpperSection from '@components/reservation-list/all/HistoryComponentUpperSection';
 
-export default function PaymentAfterConfirm() {
-  const firstStageInfoObject = usePaymentFirstStage(
-    (state) => state.firstStageInfoObject
+interface paymentAfterConfirmProp {
+  reservationId: string;
+}
+
+interface reservationInfoResponseProps {
+  result: {
+    adultCount: number;
+    teenagerCount: number;
+    kidsCount: number;
+    date: string;
+    startTime: string;
+    endTime: string;
+    gameCount: number;
+    price: number;
+    status: 'CONFIRMED' | 'TBC' | 'DECLINED' | 'CANCELED' | 'DONE' | 'REVIEWED';
+    memberId: number;
+    clubId: number;
+    type: 'GAME' | 'TIME';
+    businessHour: string;
+    clubName: string;
+    clubAddress: string;
+    reservationId: number;
+    memberName: string;
+    paymentId: string;
+    reviewId: number;
+    reviewed: boolean;
+  };
+  resultCode: number;
+  resultMsg: string;
+}
+
+export default async function PaymentAfterConfirm({
+  reservationId,
+}: paymentAfterConfirmProp) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/${reservationId}`
   );
+
+  const data: reservationInfoResponseProps = await response.json();
   return (
     <section className="w-eightNineWidth flex flex-col items-center gap-y-10 pt-[78px]">
       <div className="w-fit h-fit flex flex-col items-center">
@@ -28,14 +61,14 @@ export default function PaymentAfterConfirm() {
         </div>
       </div>
       <HistoryComponentUpperSection
-        clubName={firstStageInfoObject.clubName}
-        clubAddress={firstStageInfoObject.clubAddress}
-        eventDate={firstStageInfoObject.date}
-        eventStartTime={firstStageInfoObject.startTime}
-        eventEndTime={firstStageInfoObject.endTime}
-        adultCount={firstStageInfoObject.adultCount}
-        teenagerCount={firstStageInfoObject.teenagerCount}
-        kidsCount={firstStageInfoObject.kidsCount}
+        clubName={data.result.clubName}
+        clubAddress={data.result.clubAddress}
+        eventDate={data.result.date}
+        eventStartTime={data.result.startTime}
+        eventEndTime={data.result.endTime}
+        adultCount={data.result.adultCount}
+        teenagerCount={data.result.teenagerCount}
+        kidsCount={data.result.kidsCount}
         className="bg-white p-5"
       />
     </section>

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -12,7 +12,8 @@ interface BeforeFirstStageCardProps {
   teenagerCount: number;
   kidsCount: number;
   startTime: string;
-  endTime: string;
+  endTime?: string;
+  gameCount?: number;
   price: number;
 }
 
@@ -58,7 +59,7 @@ export default function BeforeFirstStageCard({
               ? '오전'
               : '오후'}{' '}
             {extractOnlyTime(startTime)} -{' '}
-            {endTime === '' ? null : extractOnlyTime(endTime)}
+            {endTime ? extractOnlyTime(endTime) : null}
           </span>
         </div>
         <div className="w-full border-b-[1px] border-grey4" />

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -45,9 +45,9 @@ export default function BeforeFirstStageCard({
           <span className="title4 text-grey4">인원</span>
           <span className="body4 text-grey6">
             {adultCount !== 0 && `성인 ${adultCount}명`}
-            {adultCount && teenagerCount !== 0 && ','}{' '}
-            {teenagerCount !== 0 && `청소년 ${teenagerCount}명`}{' '}
-            {teenagerCount && kidsCount !== 0 && ','}
+            {adultCount !== 0 && (teenagerCount || kidsCount) !== 0 && ', '}
+            {teenagerCount !== 0 && `청소년 ${teenagerCount}명`}
+            {teenagerCount !== 0 && kidsCount !== 0 && ', '}
             {kidsCount !== 0 && `어린이 ${kidsCount}명`}
           </span>
         </div>

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -20,6 +20,9 @@ export default function HistoryComponentUpperSection({
   kidsCount,
   className,
 }: HistoryComponentUpperSectionProps) {
+  console.log(teenagerCount);
+  console.log(kidsCount);
+  console.log(adultCount);
   return (
     <section
       id="this-is-upper-section"
@@ -58,11 +61,11 @@ export default function HistoryComponentUpperSection({
           <div className="w-full h-fit flex justify-start items-center gap-x-[6px]">
             <SmallPersonSVG />
             <span className="body4 text-grey7 txt-overflow-ellipsis">
-              {adultCount && `성인 ${adultCount}명`}
-              {adultCount && teenagerCount && ','}{' '}
-              {teenagerCount && `청소년 ${teenagerCount}명`}
-              {teenagerCount && kidsCount && ','}{' '}
-              {kidsCount && `어린이 ${kidsCount}명`}
+              {adultCount !== 0 && `성인 ${adultCount}명`}
+              {adultCount !== 0 && (teenagerCount || kidsCount) !== 0 && ', '}
+              {teenagerCount !== 0 && `청소년 ${teenagerCount}명`}
+              {teenagerCount !== 0 && kidsCount !== 0 && ', '}
+              {kidsCount !== 0 && `어린이 ${kidsCount}명`}
             </span>
           </div>
         </div>

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -27,7 +27,6 @@ export default function MakeResButtonCard() {
         gameCount: String(gameResInfo.gameCount),
         request: gameResInfo.request,
         // price: '금액 by BE',
-        clubId: clubId,
         adultCount: String(gameResInfo.adultCount),
         teenagerCount: String(gameResInfo.teenagerCount),
         kidsCount: String(gameResInfo.kidsCount),
@@ -35,7 +34,7 @@ export default function MakeResButtonCard() {
         address: '회사 주소 by BE',
       };
       const queryString = new URLSearchParams(query).toString();
-      router.push(`/payment/before/1?${queryString}`);
+      router.push(`/payment/before/${clubId}?${queryString}`);
     } else {
       console.log('timeResInfo', timeResInfo);
       if (!clubId) return; // clubId가 undefined, null, ''과 같은 경우
@@ -46,7 +45,6 @@ export default function MakeResButtonCard() {
         endTime: timeResInfo.endTime,
         request: timeResInfo.request,
         // price: '금액 by BE',
-        clubId: clubId,
         adultCount: String(timeResInfo.adultCount),
         teenagerCount: String(timeResInfo.teenagerCount),
         kidsCount: String(timeResInfo.kidsCount),
@@ -54,7 +52,7 @@ export default function MakeResButtonCard() {
         address: '회사 주소 by BE',
       };
       const queryString = new URLSearchParams(query).toString();
-      router.push(`/payment/before/1?${queryString}`);
+      router.push(`/payment/before/${clubId}?${queryString}`);
     }
   };
   return (

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -9,6 +9,7 @@ import { usePathname, useRouter } from 'next/navigation';
 export default function MakeResButtonCard() {
   const router = useRouter();
   const pathname = usePathname();
+  const clubId = pathname.split('/').at(-1);
   const timeResInfo = useTimeReservationStore(
     (state) => state.timeReservationInfo
   );
@@ -18,13 +19,15 @@ export default function MakeResButtonCard() {
   const handleReservation = () => {
     if (pathname.startsWith('/reservation/game')) {
       console.log('gameResInfo', gameResInfo);
+      if (!clubId) return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
         gametype: 'GAME',
         date: gameResInfo.date,
         startTime: gameResInfo.startTime,
         gameCount: String(gameResInfo.gameCount),
         request: gameResInfo.request,
-        price: '금액 by BE',
+        // price: '금액 by BE',
+        clubId: clubId,
         adultCount: String(gameResInfo.adultCount),
         teenagerCount: String(gameResInfo.teenagerCount),
         kidsCount: String(gameResInfo.kidsCount),
@@ -35,13 +38,15 @@ export default function MakeResButtonCard() {
       router.push(`/payment/before/1?${queryString}`);
     } else {
       console.log('timeResInfo', timeResInfo);
+      if (!clubId) return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
         gametype: 'TIME',
         date: timeResInfo.date,
         startTime: timeResInfo.startTime,
         endTime: timeResInfo.endTime,
         request: timeResInfo.request,
-        price: '금액 by BE',
+        // price: '금액 by BE',
+        clubId: clubId,
         adultCount: String(timeResInfo.adultCount),
         teenagerCount: String(timeResInfo.teenagerCount),
         kidsCount: String(timeResInfo.kidsCount),

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -19,7 +19,15 @@ export default function MakeResButtonCard() {
   const handleReservation = () => {
     if (pathname.startsWith('/reservation/game')) {
       console.log('gameResInfo', gameResInfo);
-      if (!clubId) return; // clubId가 undefined, null, ''과 같은 경우
+      if (
+        !clubId ||
+        !gameResInfo.startTime ||
+        !gameResInfo.gameCount ||
+        (gameResInfo.adultCount === 0 &&
+          gameResInfo.teenagerCount === 0 &&
+          gameResInfo.kidsCount === 0)
+      )
+        return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
         gametype: 'GAME',
         date: gameResInfo.date,
@@ -37,7 +45,15 @@ export default function MakeResButtonCard() {
       router.push(`/payment/before/${clubId}?${queryString}`);
     } else {
       console.log('timeResInfo', timeResInfo);
-      if (!clubId) return; // clubId가 undefined, null, ''과 같은 경우
+      if (
+        !clubId ||
+        !timeResInfo.startTime ||
+        !timeResInfo.endTime ||
+        (timeResInfo.adultCount === 0 &&
+          timeResInfo.teenagerCount === 0 &&
+          timeResInfo.kidsCount === 0)
+      )
+        return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
         gametype: 'TIME',
         date: timeResInfo.date,

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -29,7 +29,7 @@ export default function MakeResButtonCard() {
       )
         return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
-        gametype: 'GAME',
+        gameType: 'GAME',
         date: gameResInfo.date,
         startTime: gameResInfo.startTime,
         gameCount: String(gameResInfo.gameCount),
@@ -55,7 +55,7 @@ export default function MakeResButtonCard() {
       )
         return; // clubId가 undefined, null, ''과 같은 경우
       const query = {
-        gametype: 'TIME',
+        gameType: 'TIME',
         date: timeResInfo.date,
         startTime: timeResInfo.startTime,
         endTime: timeResInfo.endTime,

--- a/src/components/search/ChooseCard.tsx
+++ b/src/components/search/ChooseCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useState } from 'react';
+import { useState } from 'react';
 import CountDownSVG from '@public/svg/countDown.svg';
 import CountUpSVG from '@public/svg/countUp.svg';
 import { ChooseCardProps } from 'types/search/SearchTypes';

--- a/src/store/makeReservationInfo.ts
+++ b/src/store/makeReservationInfo.ts
@@ -3,17 +3,17 @@ import { create } from 'zustand';
 
 interface MakeReservationInfoProps {
   date: string;
-  startTime: string;
+  startTime: string | null;
   adultCount: number;
   teenagerCount: number;
   kidsCount: number;
   request: string;
 }
 interface MakeGameReservationInfoProps extends MakeReservationInfoProps {
-  gameCount: number;
+  gameCount: number | null;
 }
 interface MakeTimeReservationInfoProps extends MakeReservationInfoProps {
-  endTime: string;
+  endTime: string | null;
 }
 
 interface GameReservationStore {
@@ -29,12 +29,12 @@ interface TimeReservationStore {
 export const useGameReservationStore = create<GameReservationStore>((set) => ({
   gameReservationInfo: {
     date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
-    startTime: '',
+    startTime: null,
     adultCount: 0,
     teenagerCount: 0,
     kidsCount: 0,
     request: '',
-    gameCount: 0,
+    gameCount: null,
   },
   setGameReservationInfo: (info) => set({ gameReservationInfo: info }),
 }));
@@ -42,8 +42,8 @@ export const useGameReservationStore = create<GameReservationStore>((set) => ({
 export const useTimeReservationStore = create<TimeReservationStore>((set) => ({
   timeReservationInfo: {
     date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
-    startTime: '',
-    endTime: '',
+    startTime: null,
+    endTime: null,
     adultCount: 0,
     teenagerCount: 0,
     kidsCount: 0,

--- a/src/store/makeReservationInfo.ts
+++ b/src/store/makeReservationInfo.ts
@@ -8,6 +8,7 @@ interface MakeReservationInfoProps {
   teenagerCount: number;
   kidsCount: number;
   request: string;
+  clubId: string | null; // 실제로는 숫자지만 문자열로 쿼리스트링으로 넘김
 }
 interface MakeGameReservationInfoProps extends MakeReservationInfoProps {
   gameCount: number;
@@ -35,6 +36,7 @@ export const useGameReservationStore = create<GameReservationStore>((set) => ({
     kidsCount: 0,
     request: '',
     gameCount: 0,
+    clubId: null,
   },
   setGameReservationInfo: (info) => set({ gameReservationInfo: info }),
 }));
@@ -48,6 +50,7 @@ export const useTimeReservationStore = create<TimeReservationStore>((set) => ({
     teenagerCount: 0,
     kidsCount: 0,
     request: '',
+    clubId: null,
   },
   setTimeReservationInfo: (info) => set({ timeReservationInfo: info }),
 }));

--- a/src/store/makeReservationInfo.ts
+++ b/src/store/makeReservationInfo.ts
@@ -10,7 +10,7 @@ interface MakeReservationInfoProps {
   request: string;
 }
 interface MakeGameReservationInfoProps extends MakeReservationInfoProps {
-  gameCount: number | null;
+  gameCount: number;
 }
 interface MakeTimeReservationInfoProps extends MakeReservationInfoProps {
   endTime: string | null;
@@ -26,28 +26,31 @@ interface TimeReservationStore {
   setTimeReservationInfo: (info: MakeTimeReservationInfoProps) => void;
 }
 
+export const gameReservationInfoInitialState: MakeGameReservationInfoProps = {
+  date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
+  startTime: null,
+  adultCount: 0,
+  teenagerCount: 0,
+  kidsCount: 0,
+  request: '',
+  gameCount: 0,
+};
+
 export const useGameReservationStore = create<GameReservationStore>((set) => ({
-  gameReservationInfo: {
-    date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
-    startTime: null,
-    adultCount: 0,
-    teenagerCount: 0,
-    kidsCount: 0,
-    request: '',
-    gameCount: null,
-  },
+  gameReservationInfo: gameReservationInfoInitialState,
   setGameReservationInfo: (info) => set({ gameReservationInfo: info }),
 }));
 
+export const timeReservationInfoInitialState = {
+  date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
+  startTime: null,
+  endTime: null,
+  adultCount: 0,
+  teenagerCount: 0,
+  kidsCount: 0,
+  request: '',
+};
 export const useTimeReservationStore = create<TimeReservationStore>((set) => ({
-  timeReservationInfo: {
-    date: formatDate(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
-    startTime: null,
-    endTime: null,
-    adultCount: 0,
-    teenagerCount: 0,
-    kidsCount: 0,
-    request: '',
-  },
+  timeReservationInfo: timeReservationInfoInitialState,
   setTimeReservationInfo: (info) => set({ timeReservationInfo: info }),
 }));

--- a/src/store/makeReservationInfo.ts
+++ b/src/store/makeReservationInfo.ts
@@ -8,7 +8,6 @@ interface MakeReservationInfoProps {
   teenagerCount: number;
   kidsCount: number;
   request: string;
-  clubId: string | null; // 실제로는 숫자지만 문자열로 쿼리스트링으로 넘김
 }
 interface MakeGameReservationInfoProps extends MakeReservationInfoProps {
   gameCount: number;
@@ -36,7 +35,6 @@ export const useGameReservationStore = create<GameReservationStore>((set) => ({
     kidsCount: 0,
     request: '',
     gameCount: 0,
-    clubId: null,
   },
   setGameReservationInfo: (info) => set({ gameReservationInfo: info }),
 }));
@@ -50,7 +48,6 @@ export const useTimeReservationStore = create<TimeReservationStore>((set) => ({
     teenagerCount: 0,
     kidsCount: 0,
     request: '',
-    clubId: null,
   },
   setTimeReservationInfo: (info) => set({ timeReservationInfo: info }),
 }));

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -8,7 +8,8 @@ export interface paymentFirstStageInfoProps {
   teenagerCount: number;
   kidsCount: number;
   startTime: string;
-  endTime: string;
+  endTime?: string;
+  gameCount?: number;
   price: number;
 }
 

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -17,7 +17,7 @@ export interface HistoryInProgressItemProps {
     | 'REVIEWED';
   reservationId: number;
   paymentId: string | null;
-  handleChangeCancelPaymentId?: (paymentId: string) => void;
+  handleChangeCancelPaymentId: (paymentId: string) => void;
 }
 
 export interface HistoryComponentUpperSectionProps

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -1,8 +1,27 @@
-import { ResultCardProps } from 'types/search/result/searchResult';
 import { deleteFromWishList } from '../../apis/wishlist/deleteFromWishlist';
+import { ResultCardProps } from 'types/search/result/searchResult';
+
+export interface wishListItemProps {
+  id: number;
+  clubName: string;
+  address: string;
+  ratingSum: number;
+  ratingCount: number;
+  avgRating: number;
+  price: number;
+  phoneNumber: string;
+  snsLink: string;
+  businessHours: string;
+  latitude: number;
+  longitude: number;
+  category: string;
+  type: 'GAME' | 'TIME';
+  imageUrls: string[];
+  presignedImageUrls: string[];
+}
 
 export interface WishListResponse {
-  result: ResultCardProps[];
+  result: ResultCardProps[] | null;
   resultCode: number;
   resultMsg: string;
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -26,3 +26,21 @@ export const extractOnlyTime = (dt: string): string => {
 
   return `${hours}:${minutes}`;
 };
+
+// DATE 객체를 받아들여 몇시간의 차이가 나는지를 계산해주는 함수
+export const calculateTimeDiff = (
+  firstDate: string,
+  secondDate: string
+): number => {
+  // 문자열을 Date 객체로 변환
+  const date1 = new Date(firstDate);
+  const date2 = new Date(secondDate);
+
+  // 두 Date 객체의 차이를 밀리초 단위로 계산
+  const diffInMilliseconds = Math.abs(date2.getTime() - date1.getTime());
+
+  // 밀리초를 시간 단위로 변환
+  const diffInHours = diffInMilliseconds / (1000 * 60 * 60);
+
+  return diffInHours;
+};


### PR DESCRIPTION
조금 내용이 많은데, 핵심은 몇개 없음
1. 기존에는 /reservation/time 이나 /reservation/game 페이지에서 /payment/before로 넘어갈 때, 쿼리 스트링으로 가격, 인원 정보, 시작 시간 등의 정보르 넘겨줬음. 근데 지난번에 우리가 얘기했듯이 이건 사용자가 직접 조작할 수 있기 때문에 위험함. 따라서 `/payment/before/{clubId}`의 clubId를 백엔드에 조회해서 가격 정보를 가져올 거임. 그렇게 가져온 가격 정보 * 게임수 혹은 시간(종료시간과 시작시간 빼서 시간 단위 구하는 유틸함수 만들어놨음).
2. 업체마다 `game` 예약인 곳이 있고 `time` 예약인 곳이 있잖슴. 일단 쿼리 스트링으로도 넘기긴 하는데 백엔드에 clubId로 조회해서 타입이 TIME인지 GAME인지 일치 안하면 홈페이지로 리다이렉트 시켜버림.
3. **/reservation/time**이나 **/reservation/game** 페이지에서 종료시간, 인원 설정, 게임수 설정 이런거 안하면 버튼 클릭해도 /payment/before 페이지로 못 넘어가게 막아줬음 -> **early return**문 활용
4. 일단 포트원에 관련 예약 정보를 웬만한거 다 넘길거임. 그래야 백엔드에서도 `paymentId`를 들고 확인을 할 때 좀 더 편할 거 같음. 이는 kakaoPay와 toss의 결제 함수에 `customData` 라는 객체 필드로 들어갔음
5. 결제를 하고, paymentId를 백엔드로 넘기고 응답이 괜찮으면 `/api/v1/reservation/{clubId}`로 post 요청을 보내는 예약을 진행함
6. 기존의 `/reservation/game/{clubId}`, `/reservation/time/{clubId}` 페이지에서 컴포넌트가 언마운트 될때 전역 상태 초기화 정리가 안되어서 페이지를 왔다갔다 할 경우 인원 수가 영향 받는 일이 있었음. 해당 page.tsx 컴포넌트들을 클라이언트 컴포넌트로 전환하고, 이것이 언마운트 될 때 싹다 정리해주는 로직을 사용했음. -> 근데 이건 반대로 생각해보면 `ChooseCard` 컴포넌트가 마운트 될때 초기화를 때려버려도 될 것 같긴함. 그러면 page.tsx 컴포넌트는 기존의 방식인 서버 컴포넌트로 끌고 갈 수 있음