### PR TITLE
Fix/publishing

### DIFF
--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -27,6 +27,10 @@ const handleKakaokEasyPay = async (
     memberId: number;
   }
 ): Promise<kakaoEasyPayBackendResponse> => {
+  const clubDataResonse = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/${reservationData.clubId}`
+  );
+  const clubData = await clubDataResonse.json();
   // redirect로 보낼 query string임
   const query = {
     clubId: reservationData.clubId.toString(),
@@ -40,13 +44,14 @@ const handleKakaokEasyPay = async (
     teenagerCount: reservationData.teenagerCount.toString(),
     kidsCount: reservationData.kidsCount.toString(),
     // paymentId: customPaymentId,
-    clubPrice: (
-      paymentPrice /
-      calculateTimeDiff(
-        reservationData.endTime as string,
-        reservationData.startTime
-      )
-    ).toString(),
+    // clubPrice: (
+    //   paymentPrice /
+    //   calculateTimeDiff(
+    //     reservationData.endTime as string,
+    //     reservationData.startTime
+    //   )
+    // ).toString(),
+    clubPrice: clubData.result.price,
     paymentPrice: paymentPrice.toString(),
   };
 
@@ -85,12 +90,7 @@ const handleKakaokEasyPay = async (
       startTime: reservationData.startTime,
       endTime: reservationData.endTime,
       gameCount: reservationData.gameCount,
-      clubPrice:
-        paymentPrice /
-        calculateTimeDiff(
-          reservationData.endTime as string,
-          reservationData.startTime
-        ),
+      clubPrice: clubData.result.price,
       clubId: reservationData.clubId,
       paymentId: response?.paymentId,
       paymentPrice: paymentPrice,

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -28,6 +28,10 @@ const handleTossEasyPay = async (
     memberId: number;
   }
 ): Promise<tossEasyPayBackendResponse> => {
+  const clubDataResonse = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/${reservationData.clubId}`
+  );
+  const clubData = await clubDataResonse.json();
   const query = {
     clubId: reservationData.clubId.toString(),
     date: reservationData.date,
@@ -40,13 +44,14 @@ const handleTossEasyPay = async (
     teenagerCount: reservationData.teenagerCount.toString(),
     kidsCount: reservationData.kidsCount.toString(),
     // paymentId: customPaymentId,
-    clubPrice: (
-      paymentPrice /
-      calculateTimeDiff(
-        reservationData.endTime as string,
-        reservationData.startTime
-      )
-    ).toString(),
+    // clubPrice: (
+    //   paymentPrice /
+    //   calculateTimeDiff(
+    //     reservationData.endTime as string,
+    //     reservationData.startTime
+    //   )
+    // ).toString(),
+    clubPrice: clubData.result.price,
     paymentPrice: paymentPrice.toString(),
   };
 

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -90,12 +90,7 @@ const handleTossEasyPay = async (
       startTime: reservationData.startTime,
       endTime: reservationData.endTime,
       gameCount: reservationData.gameCount,
-      clubPrice:
-        paymentPrice /
-        calculateTimeDiff(
-          reservationData.endTime as string,
-          reservationData.startTime
-        ),
+      clubPrice: clubData.result.price,
       clubId: reservationData.clubId,
       paymentId: response?.paymentId,
       paymentPrice: paymentPrice,

--- a/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
@@ -55,8 +55,8 @@ export default async function page({
           reservationId={data.result.reservationId}
           memberName={data.result.memberName}
           phoneNumber="010-4925-1427"
-          paymentTime="2024.06.18 (화) 19:51"
-          payMethod="카카오페이"
+          paymentTime={data.result.updatedAt}
+          payMethod={data.result.provider}
           price={data.result.price}
           feePrice={0} // 추후에 백엔드에서 보내줄 필요가 있음
           couponDiscountPrice={0} // 백엔드에서 보내줄 필요가 있음

--- a/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
@@ -49,7 +49,7 @@ export default async function page({
           date={data.result.date}
           startTime={data.result.startTime}
           endTime={data.result.endTime}
-          adultCount={data.result.adultCounts}
+          adultCount={data.result.adultCount}
           teenagerCount={data.result.teenagerCount}
           kidsCount={data.result.kidsCount}
           reservationId={data.result.reservationId}
@@ -58,8 +58,8 @@ export default async function page({
           paymentTime="2024.06.18 (화) 19:51"
           payMethod="카카오페이"
           price={data.result.price}
-          feePrice={0}
-          couponDiscountPrice={0}
+          feePrice={0} // 추후에 백엔드에서 보내줄 필요가 있음
+          couponDiscountPrice={0} // 백엔드에서 보내줄 필요가 있음
           cancelAvailableDate="2024년 08월 02일 13:00"
           status={data.result.status}
         />

--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -31,7 +31,7 @@ interface searchParamsProps {
   endTime?: string | undefined;
   gameCount?: number | undefined;
   clubName: string | undefined;
-  clubAddress: string | undefined;
+  address: string | undefined;
   gameType: string | undefined;
 }
 
@@ -97,11 +97,14 @@ export default function Page({
       endTime: reservationSearchParmasObject.endTime
         ? reservationSearchParmasObject.endTime
         : '',
+      gameCount: reservationSearchParmasObject.gameCount
+        ? reservationSearchParmasObject.gameCount
+        : 0,
       clubName: reservationSearchParmasObject.clubName
         ? reservationSearchParmasObject.clubName
         : '',
-      clubAddress: reservationSearchParmasObject.clubAddress
-        ? reservationSearchParmasObject.clubAddress
+      clubAddress: reservationSearchParmasObject.address
+        ? reservationSearchParmasObject.address
         : '',
       // TIME 타입이면 종료시간 - 시작 시간을 빼서 가격과 곱하고, GAME 타입이면 게임 카운트를 가격에 곱해 계산. type 검사는 쿼리 스트링, 백엔드 api 응답 데이터 이중 검사
       price: clubSpecificInfoResponse.data?.result.price

--- a/src/app/payment/redirect/page.tsx
+++ b/src/app/payment/redirect/page.tsx
@@ -53,7 +53,9 @@ export default function PaymentRedirect({
             kidsCount: parseInt(searchParams.kidsCount as string),
             date: searchParams.date as string,
             startTime: searchParams.startTime as string,
-            endTime: searchParams.endTime as string,
+            endTime: (searchParams.endTime as string)
+              ? (searchParams.endTime as string)
+              : undefined,
             gameCount: parseInt(searchParams.gameCount as string),
             price: parseInt(searchParams.paymentPrice as string),
             status: 'TBC',

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -231,7 +231,10 @@ export default function FullButton({
                   kidsCount: firstStageInfoObject.kidsCount,
                   date: firstStageInfoObject.date,
                   startTime: firstStageInfoObject.startTime,
-                  endTime: firstStageInfoObject.endTime,
+                  endTime:
+                    firstStageInfoObject.endTime !== ''
+                      ? firstStageInfoObject.endTime
+                      : undefined,
                   gameCount: firstStageInfoObject.gameCount,
                   price:
                     secondStageInfoObject.price -
@@ -290,7 +293,10 @@ export default function FullButton({
                   kidsCount: firstStageInfoObject.kidsCount,
                   date: firstStageInfoObject.date,
                   startTime: firstStageInfoObject.startTime,
-                  endTime: firstStageInfoObject.endTime,
+                  endTime:
+                    firstStageInfoObject.endTime !== ''
+                      ? firstStageInfoObject.endTime
+                      : undefined,
                   gameCount: firstStageInfoObject.gameCount,
                   price:
                     secondStageInfoObject.price -

--- a/src/components/mypage/ProfileInformationItem.tsx
+++ b/src/components/mypage/ProfileInformationItem.tsx
@@ -119,7 +119,11 @@ export default function ProfileInformationItem({
               'text-grey3': inputData === '',
             })}
           >
-            {inputData !== '' ? inputData : `${labelName}을 입력해주세요`}
+            {inputData !== ''
+              ? inputData
+              : `${labelName}${
+                  labelName === '휴대폰번호' ? '를' : '을'
+                } 입력해주세요`}
           </span>
         )}
         {inputBoxEditStage === 2 && (

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -38,7 +38,8 @@ export default async function PaymentAfterConfirm({
   reservationId,
 }: paymentAfterConfirmProp) {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/${reservationId}`
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/${reservationId}`,
+    { cache: 'no-store' }
   );
 
   const data: reservationInfoResponseProps = await response.json();

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -66,7 +66,12 @@ export default function BeforeFirstStageCard({
             {endTime ? extractOnlyTime(endTime) : null}
           </span>
         </div>
-        {}
+        {endTime === '' && gameCount !== 0 && (
+          <div className="w-full flex justify-between items-center">
+            <span className="title4 text-grey4">게임수</span>
+            <span className="body4 text-grey6">{gameCount}게임</span>
+          </div>
+        )}
         <div className="w-full border-b-[1px] border-grey4" />
         <div className="w-full h-fit flex justify-between gap-x-[126px]">
           <span className="title4 text-grey6">총 결제 금액</span>

--- a/src/components/payment/before/BeforeFirstStageCard.tsx
+++ b/src/components/payment/before/BeforeFirstStageCard.tsx
@@ -26,8 +26,12 @@ export default function BeforeFirstStageCard({
   kidsCount,
   startTime,
   endTime,
+  gameCount,
   price,
 }: BeforeFirstStageCardProps) {
+  console.log(clubAddress);
+  console.log(gameCount);
+  console.log(endTime);
   return (
     <section className="w-eightNineWidth h-fit rounded-[10px] flex justify-center bg-white mt-[30px] py-5">
       <div className="w-sevenEightWidth h-fit flex flex-col gap-y-5">
@@ -58,10 +62,11 @@ export default function BeforeFirstStageCard({
             {parseInt(extractOnlyTime(startTime).slice(0, 2)) <= 12
               ? '오전'
               : '오후'}{' '}
-            {extractOnlyTime(startTime)} -{' '}
+            {extractOnlyTime(startTime)} {endTime === '' ? '시작' : '- '}
             {endTime ? extractOnlyTime(endTime) : null}
           </span>
         </div>
+        {}
         <div className="w-full border-b-[1px] border-grey4" />
         <div className="w-full h-fit flex justify-between gap-x-[126px]">
           <span className="title4 text-grey6">총 결제 금액</span>

--- a/src/components/payment/before/BeforeSecondStageUserInfoCard.tsx
+++ b/src/components/payment/before/BeforeSecondStageUserInfoCard.tsx
@@ -49,7 +49,7 @@ export default function BeforeSecondStageUserInfoCard({
           value={userName}
           onChange={handleChangeUserNameInput}
           placeholder="예약자명 입력"
-          className="title4 w-[80%] border-b-[1px] border-grey3"
+          className="title4 w-[80%] border-b-[1px] border-grey3 !leading-[1.4] !tracking-[-0.02em]"
         />
       </div>
       <div className="w-sevenEightWidth flex justify-between items-center gap-x-6">

--- a/src/components/reservation-list/reservation/PaymentInfoSection.tsx
+++ b/src/components/reservation-list/reservation/PaymentInfoSection.tsx
@@ -1,3 +1,4 @@
+import { extractReservationMoment } from '@utils/formatDate';
 interface PaymentInfoProps {
   paymentTime: string;
   payMethod: string;
@@ -13,11 +14,15 @@ export default function PaymentInfoSection({
       <div className="flex flex-col gap-y-[14px]">
         <div className="flex items-center gap-x-5">
           <span className="caption2 text-grey4">결제 일시</span>
-          <span className="caption2 text-grey6">{paymentTime}</span>
+          <span className="caption2 text-grey6">
+            {extractReservationMoment(paymentTime)}
+          </span>
         </div>
         <div className="flex items-center gap-x-5">
           <span className="caption2 text-grey4">결제 수단</span>
-          <span className="caption2 text-grey6">{payMethod}</span>
+          <span className="caption2 text-grey6">
+            {payMethod === 'TOSSPAY' ? '토스페이' : '카카오페이'}
+          </span>
         </div>
       </div>
     </section>

--- a/src/store/paymentInfoStore.ts
+++ b/src/store/paymentInfoStore.ts
@@ -29,6 +29,7 @@ export const usePaymentFirstStage = create<paymentFirstStageStore>((set) => ({
     kidsCount: 0,
     startTime: '',
     endTime: '',
+    gameCount: 0,
     price: 0,
   },
   setFirstStageInfoObject: (status: paymentFirstStageInfoProps) =>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -44,3 +44,23 @@ export const calculateTimeDiff = (
 
   return diffInHours;
 };
+
+export const extractReservationMoment = (timestamp: string): string => {
+  // 문자열을 Date 객체로 변환
+  let date = new Date(timestamp);
+
+  // 요일 정보
+  let days = ['일', '월', '화', '수', '목', '금', '토'];
+  let dayOfWeek = days[date.getUTCDay()];
+
+  // 원하는 형식으로 변환
+  let year = date.getUTCFullYear();
+  let month = ('0' + (date.getUTCMonth() + 1)).slice(-2);
+  let day = ('0' + date.getUTCDate()).slice(-2);
+  let hours = ('0' + date.getUTCHours()).slice(-2);
+  let minutes = ('0' + date.getUTCMinutes()).slice(-2);
+
+  let formattedTime = `${year}.${month}.${day} (${dayOfWeek}) ${hours}:${minutes}`;
+
+  return formattedTime;
+};


### PR DESCRIPTION
디자이너들이 해준 UI 수정

1. 예약 상세 페이지에서의 결제 일시, 결제 방법 데이터 받아와서 추가
2. 기존에는 clubPrice 해당 업체의 가격 정보를 백엔드에 verification 할때 `지불 금액/ (종료시간 - 시작시간)` 로직으로 해줬는데 이건 게임당 예약에서 불가능했음. 따라서 그냥 잔머리 안 굴리고 clubId를 기반으로 해당 club의 가격 정보를 받아와서 clubPrice를 넘겼음
3. 서버 컴포넌트로 만든 페이지들의 데이터가 `ssg`가 디폴트라서 out of dated 된 경우가 있었음. 따라서 fetch() 함수에 `{cache : 'no-store'}` 를 추가해줬음
4. /payment/before 1단계에서 게임 예약일 경우 `오전 10:00 시작` UI로 바꿔주고 아래에 선택적으로 게임 수 UI도 더해줬음