### PR TITLE
Fix/UI

### DIFF
--- a/src/apis/search/getLoginUserSearchedResult.ts
+++ b/src/apis/search/getLoginUserSearchedResult.ts
@@ -1,0 +1,31 @@
+import { instance } from '@apis/instance';
+import { useQuery } from '@tanstack/react-query';
+import { ResultCardProps } from 'types/search/result/searchResult';
+
+interface SearchResearchResponse {
+  result: {
+    searchList: ResultCardProps[];
+    avgLatitude: number;
+    avgLongitude: number;
+  };
+  resultCode: number;
+  resultMsg: string;
+}
+
+export const getLoginUserSearchedResult = async (
+  search: string
+): Promise<SearchResearchResponse> => {
+  return instance.get(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/search/user?search=${search}`
+  );
+};
+
+export const useGetLoginUserSearchedResult = (search: string) => {
+  return useQuery({
+    queryKey: ['loginUserSearchedResult', search], // search를 queryKey에 포함
+    queryFn: ({ queryKey }) => {
+      const searchParam = queryKey[1] as string; // search 인수 추출
+      return getLoginUserSearchedResult(searchParam);
+    },
+  });
+};

--- a/src/apis/search/getUnLoginUserSearchedResult.ts
+++ b/src/apis/search/getUnLoginUserSearchedResult.ts
@@ -12,20 +12,20 @@ interface SearchResearchResponse {
   resultMsg: string;
 }
 
-export const getSearchedResult = async (
+export const getUnLoginUserSearchedResult = async (
   search: string
 ): Promise<SearchResearchResponse> => {
   return instance.get(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/search?search=${search}`
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/search/guest?search=${search}`
   );
 };
 
-export const useGetSearchedResult = (search: string) => {
+export const useGetUnLoginUserSearchedResult = (search: string) => {
   return useQuery({
-    queryKey: ['searchedResult', search], // search를 queryKey에 포함
+    queryKey: ['unLoginUserSearchedResult', search], // search를 queryKey에 포함
     queryFn: ({ queryKey }) => {
       const searchParam = queryKey[1] as string; // search 인수 추출
-      return getSearchedResult(searchParam);
+      return getUnLoginUserSearchedResult(searchParam);
     },
   });
 };

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -132,6 +132,7 @@ export default function Page() {
                     eventDate={reservationItem.date}
                     eventStartTime={reservationItem.startTime}
                     eventEndTime={reservationItem.endTime}
+                    gameCount={reservationItem.gameCount}
                     adultCount={reservationItem.adultCount}
                     teenagerCount={reservationItem.teenagerCount}
                     kidsCount={reservationItem.kidsCount}
@@ -148,6 +149,7 @@ export default function Page() {
                     eventDate={reservationItem.date}
                     eventStartTime={reservationItem.startTime}
                     eventEndTime={reservationItem.endTime}
+                    gameCount={reservationItem.gameCount}
                     adultCount={reservationItem.adultCount}
                     teenagerCount={reservationItem.teenagerCount}
                     kidsCount={reservationItem.kidsCount}
@@ -181,6 +183,7 @@ export default function Page() {
                     eventDate={data.date}
                     eventStartTime={data.startTime}
                     eventEndTime={data.endTime}
+                    gameCount={data.gameCount}
                     adultCount={data.adultCount}
                     teenagerCount={data.teenagerCount}
                     kidsCount={data.kidsCount}
@@ -212,6 +215,7 @@ export default function Page() {
                   eventDate={data.date}
                   eventStartTime={data.startTime}
                   eventEndTime={data.endTime}
+                  gameCount={data.gameCount}
                   adultCount={data.adultCount}
                   teenagerCount={data.teenagerCount}
                   kidsCount={data.kidsCount}

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -155,7 +155,7 @@ export default function Page() {
                     kidsCount={reservationItem.kidsCount}
                     reservationStatus={reservationItem.status}
                     reservationId={reservationItem.reservationId} //일단 백엔드에서 추후에 예약과 review id를 줌
-                    // reviewId={}
+                    reviewId={reservationItem.reviewId}
                   />
                 )
               )}
@@ -221,7 +221,7 @@ export default function Page() {
                   kidsCount={data.kidsCount}
                   reservationStatus={data.status}
                   reservationId={index}
-                  reviewId={index}
+                  reviewId={data.reviewId}
                 />
               ))}
             </main>

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -188,7 +188,7 @@ export default function Page() {
                     teenagerCount={data.teenagerCount}
                     kidsCount={data.kidsCount}
                     reservationStatus={data.status}
-                    reservationId={index}
+                    reservationId={data.reservationId}
                     paymentId={cancelPaymentId}
                     handleChangeCancelPaymentId={setCancelPaymentId}
                   />
@@ -220,7 +220,7 @@ export default function Page() {
                   teenagerCount={data.teenagerCount}
                   kidsCount={data.kidsCount}
                   reservationStatus={data.status}
-                  reservationId={index}
+                  reservationId={data.reservationId}
                   reviewId={data.reviewId}
                 />
               ))}

--- a/src/app/(NavBarCommonLayout)/reservation-list/review/[reviewId]/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/review/[reviewId]/page.tsx
@@ -1,30 +1,76 @@
 import Header from '@components/all/Header';
-import NavBar from '@components/all/NavBar/NavBar';
 import Review from '@components/reservation-list/review/Review';
 import { ReviewProps } from 'types/reservation-list/review/ReservationListReviewPageTypes';
+// reviewId로 해당 review를 따와서 보여줘야 됨
 
-export default function page() {
-  const DUMMYREVIEWDATA: ReviewProps = {
-    clubName: '스카이락볼링장',
-    clubAddress: '서울 서대문구 신촌로 73',
-    eventDate: '05.17 (금)',
-    eventStartTime: '오전 10:00',
-    eventEndTime: '오전 11:00',
-    adultCount: 2,
-    reservationUserName: '김티그',
-    rating: 4,
-    rateContent:
-      '역 근처에 시설도 깔끔하고 좋아요! 신촌 볼링장 하면 꼭 여기로 가요. 직원분들도 친절하고 레일도 많고 최고! 담에 친구들이랑 단체 모임하면 또 갈게요~!',
+interface reviewIdPathnameProp {
+  params: {
+    reviewId: string;
   };
+}
+
+interface reviewResponse {
+  imageUrl?: string;
+  clubName: string;
+  clubAddress: string;
+  eventDate: string;
+  eventStartTime: string;
+  eventEndTime: string;
+  gameCount: number | null;
+  adultCount?: number;
+  teenagerCount?: number;
+  kidsCount?: number;
+  className?: string;
+  reservationUserName: string;
+  rating: number;
+  rateContent: string;
+}
+
+export default async function Page({ params }: reviewIdPathnameProp) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/review/${params.reviewId}`
+  );
+
+  const reviewData = await response.json();
+
+  console.log(reviewData);
+
+  const reviewDataObject = {
+    clubName: reviewData.result.reservation.clubName,
+    clubAddress: reviewData.result.reservation.clubAddress,
+    eventDate: reviewData.result.reservation.date,
+    eventStartTime: reviewData.result.reservation.startTime,
+    eventEndTime: reviewData.result.reservation.endTime,
+    gameCount: reviewData.result.reservation.gameCount,
+    adultCount: reviewData.result.reservation.adultCount,
+    teenagerCount: reviewData.result.reservation.teenagerCount,
+    kidsCount: reviewData.result.reservation.kidsCount,
+    reservationUserName: reviewData.result.reservation.memberName,
+    rating: reviewData.result.review.rating,
+    rateContent: reviewData.result.review.contents,
+  };
+
+  // const DUMMYREVIEWDATA: ReviewProps = {
+  //   clubName: '스카이락볼링장',
+  //   clubAddress: '서울 서대문구 신촌로 73',
+  //   eventDate: '05.17 (금)',
+  //   eventStartTime: '오전 10:00',
+  //   eventEndTime: '오전 11:00',
+  //   gameCount: 0,
+  //   adultCount: 2,
+  //   reservationUserName: '김티그',
+  //   rating: 4,
+  //   rateContent:
+  //     '역 근처에 시설도 깔끔하고 좋아요! 신촌 볼링장 하면 꼭 여기로 가요. 직원분들도 친절하고 레일도 많고 최고! 담에 친구들이랑 단체 모임하면 또 갈게요~!',
+  // };
 
   return (
     <div className="flex flex-col h-full relative ">
       <Header buttonType="back" title="작성한 리뷰" />
 
       <main className="pt-[68px] w-full h-fit flex justify-center">
-        <Review {...DUMMYREVIEWDATA} />
+        <Review {...reviewDataObject} />
       </main>
-      {/* <NavBar /> */}
     </div>
   );
 }

--- a/src/app/(NavBarCommonLayout)/reservation-list/review/[reviewId]/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/review/[reviewId]/page.tsx
@@ -28,7 +28,8 @@ interface reviewResponse {
 
 export default async function Page({ params }: reviewIdPathnameProp) {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/review/${params.reviewId}`
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/review/${params.reviewId}`,
+    { cache: 'no-store' }
   );
 
   const reviewData = await response.json();

--- a/src/app/(NavBarCommonLayout)/search/result/SearchResult.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/SearchResult.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useGetSearchedResult } from '@apis/search/getSearchedResult';
+import { useGetLoginUserSearchedResult } from '@apis/search/getLoginUserSearchedResult';
 import NavBar from '@components/all/NavBar/NavBar';
 import SearchHeader from '@components/all/SearchHeader';
 import Tabs from '@components/all/Tabs/Tabs';
@@ -19,6 +19,7 @@ import { ko } from 'date-fns/locale';
 import { useSearchParams } from 'next/navigation';
 import { use, useEffect, useState } from 'react';
 import { ResultCardProps } from 'types/search/result/searchResult';
+import { useGetUnLoginUserSearchedResult } from '@apis/search/getUnLoginUserSearchedResult';
 
 const isResult = true;
 
@@ -45,7 +46,10 @@ export function SearchResult() {
     Object.fromEntries(searchParams.entries());
   const parsedDate = parse(date, "yyyy-MM-dd'T'HH:mm:ss", new Date());
   const formattedDate = formatDate(parsedDate, 'M.dd (EEE)', { locale: ko });
-  const { data } = useGetSearchedResult(search);
+  const loginUserSearchResult = useGetLoginUserSearchedResult(search);
+  console.log(loginUserSearchResult.data);
+  const UnLoginUserSearchResult = useGetUnLoginUserSearchedResult(search);
+  console.log(UnLoginUserSearchResult.data);
 
   useEffect(() => {
     console.log(selectedOption);
@@ -55,48 +59,67 @@ export function SearchResult() {
       const sortedResult = searchResult.sort((a, b) => {
         return b.avgRating - a.avgRating;
       });
-      setSearchResult(prev => sortedResult);
+      setSearchResult((prev) => sortedResult);
       console.log(sortedResult);
     } else if (selectedOption === '가까운순') {
       const sortedResult = searchResult.sort((a, b) => {
         return (a.distance || 0) - (b.distance || 0);
       });
-      setSearchResult(prev => sortedResult);
+      setSearchResult((prev) => sortedResult);
       console.log(sortedResult);
     } else if (selectedOption === '고가순') {
       const sortedResult = searchResult.sort((a, b) => {
         return a.price - b.price;
       });
-      setSearchResult(prev => sortedResult);
+      setSearchResult((prev) => sortedResult);
       console.log(sortedResult);
     } else if (selectedOption === '저가순') {
       const sortedResult = searchResult.sort((a, b) => {
         return b.price - a.price;
       });
-      setSearchResult(prev => sortedResult);
+      setSearchResult((prev) => sortedResult);
       console.log(sortedResult);
     } else if (selectedOption === '리뷰많은순') {
       const sortedResult = searchResult.sort((a, b) => {
         return b.ratingCount - a.ratingCount;
       });
-      setSearchResult(prev => sortedResult);
+      setSearchResult((prev) => sortedResult);
       console.log(sortedResult);
     }
   }, [selectedOption]);
 
   useEffect(() => {
-    if (data) {
-      console.log(data?.result.avgLatitude);
-      console.log(data?.result.avgLongitude);
-      console.log(data?.result.searchList);
+    if (loginUserSearchResult.data?.result !== null) {
+      console.log(loginUserSearchResult.data?.result.avgLatitude);
+      console.log(loginUserSearchResult.data?.result.avgLongitude);
+      console.log(loginUserSearchResult.data?.result.searchList);
       setCurrentLocation({
-        latitude: data?.result.avgLatitude || 37.55527,
-        longitude: data?.result.avgLongitude || 126.9366,
+        latitude: loginUserSearchResult.data?.result.avgLatitude || 37.55527,
+        longitude: loginUserSearchResult.data?.result.avgLongitude || 126.9366,
       });
-      setSearchResult(data?.result.searchList || []);
-      setOriginalSearchResult(data?.result.searchList || []);
+      setSearchResult(loginUserSearchResult.data?.result.searchList || []);
+      setOriginalSearchResult(
+        loginUserSearchResult.data?.result.searchList || []
+      );
+      return;
     }
-  }, [data]);
+
+    if (UnLoginUserSearchResult.data !== null) {
+      console.log(UnLoginUserSearchResult.data?.result.avgLatitude);
+      console.log(UnLoginUserSearchResult.data?.result.avgLongitude);
+      console.log(UnLoginUserSearchResult.data?.result.searchList);
+      setCurrentLocation({
+        latitude: UnLoginUserSearchResult.data?.result.avgLatitude || 37.55527,
+        longitude:
+          UnLoginUserSearchResult.data?.result.avgLongitude || 126.9366,
+      });
+      setSearchResult(UnLoginUserSearchResult.data?.result.searchList || []);
+      setOriginalSearchResult(
+        UnLoginUserSearchResult.data?.result.searchList || []
+      );
+      return;
+    }
+  }, [loginUserSearchResult.data, UnLoginUserSearchResult.data]);
 
   const selectedTab = useTab((state) => state.selectedTab);
 
@@ -124,6 +147,9 @@ export function SearchResult() {
       });
     });
   };
+
+  console.log(searchResult);
+  console.log(originalSearchResult);
 
   return (
     <div className="w-full h-full flex justify-center items-center text-[200px]">

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -207,8 +207,8 @@ export default function Page({
               />
               <div className="w-full border-b-[1px] border-grey2" />
               <ReviewLowerSection
-                reservationUserName="김티그"
-                eventDate={data.result.date.replace(/-/g, '.')}
+                reservationUserName={data.result.memberName as string}
+                eventDate={data.result.date}
                 adultCount={data.result.adultCount}
                 teenagerCount={data.result.teenagerCount}
                 kidsCount={data.result.kidsCount}

--- a/src/app/writing-review/[reservationId]/page.tsx
+++ b/src/app/writing-review/[reservationId]/page.tsx
@@ -22,6 +22,7 @@ const DUMMYREVIEWDATA: HistoryComponentUpperSectionProps = {
   eventDate: '05.10 (수)',
   eventStartTime: '오전 10:00',
   eventEndTime: '오전 11:00',
+  gameCount: 0,
   adultCount: 8,
 };
 
@@ -83,10 +84,11 @@ export default function Page({
               <div className="w-full h-fit bg-white p-5 rounded-xl">
                 <HistoryComponentUpperSection
                   className="bg-white"
-                  imageUrl={DUMMYREVIEWDATA.imageUrl}
+                  // imageUrl={DUMMYREVIEWDATA.imageUrl}
                   clubAddress={data.result.clubAddress}
                   clubName={data.result.clubName}
                   eventDate={data.result.date}
+                  gameCount={data.result.gameCount}
                   eventEndTime={data.result.endTime}
                   eventStartTime={data.result.startTime}
                   adultCount={data.result.adultCount}
@@ -192,10 +194,11 @@ export default function Page({
             <section className="w-full h-fit p-5 flex flex-col gap-y-5 bg-white">
               <HistoryComponentUpperSection
                 className="bg-white"
-                imageUrl={DUMMYREVIEWDATA.imageUrl}
+                // imageUrl={DUMMYREVIEWDATA.imageUrl}
                 clubAddress={data.result.clubAddress}
                 clubName={data.result.clubName}
                 eventDate={data.result.date}
+                gameCount={data.result.gameCount}
                 eventEndTime={data.result.endTime}
                 eventStartTime={data.result.startTime}
                 adultCount={data.result.adultCount}

--- a/src/components/payment/after/PaymentAfterConfirm.tsx
+++ b/src/components/payment/after/PaymentAfterConfirm.tsx
@@ -67,6 +67,7 @@ export default async function PaymentAfterConfirm({
         eventDate={data.result.date}
         eventStartTime={data.result.startTime}
         eventEndTime={data.result.endTime}
+        gameCount={data.result.gameCount}
         adultCount={data.result.adultCount}
         teenagerCount={data.result.teenagerCount}
         kidsCount={data.result.kidsCount}

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -18,6 +18,7 @@ export default function HistoryEndItem({
   reservationId,
   reviewId,
 }: HistoryEndItemProps) {
+  console.log(reviewId);
   return (
     <Link
       href={`/reservation-list/reservation/${reservationId}`}

--- a/src/components/reservation-list/HistoryEndItem.tsx
+++ b/src/components/reservation-list/HistoryEndItem.tsx
@@ -10,6 +10,7 @@ export default function HistoryEndItem({
   eventDate,
   eventStartTime,
   eventEndTime,
+  gameCount,
   adultCount,
   teenagerCount,
   kidsCount,
@@ -28,6 +29,7 @@ export default function HistoryEndItem({
         eventDate={eventDate}
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
+        gameCount={gameCount}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -11,6 +11,7 @@ export default function HistoryInProgressItem({
   eventDate,
   eventStartTime,
   eventEndTime,
+  gameCount,
   adultCount,
   teenagerCount,
   kidsCount,
@@ -32,6 +33,7 @@ export default function HistoryInProgressItem({
         eventDate={eventDate}
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
+        gameCount={gameCount}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}

--- a/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
+++ b/src/components/reservation-list/all/HistoryComponentUpperSection.tsx
@@ -15,6 +15,7 @@ export default function HistoryComponentUpperSection({
   eventDate,
   eventStartTime,
   eventEndTime,
+  gameCount,
   adultCount,
   teenagerCount,
   kidsCount,
@@ -51,11 +52,13 @@ export default function HistoryComponentUpperSection({
               {parseInt(extractOnlyTime(eventStartTime).slice(0, 2)) <= 12
                 ? '오전'
                 : '오후'}{' '}
-              {extractOnlyTime(eventStartTime)} ~{' '}
-              {parseInt(extractOnlyTime(eventEndTime).slice(0, 2)) <= 12
-                ? '오전'
-                : '오후'}{' '}
-              {extractOnlyTime(eventEndTime)}
+              {extractOnlyTime(eventStartTime)} {gameCount ? '시작, ' : '~ '}
+              {!gameCount
+                ? parseInt(extractOnlyTime(eventEndTime).slice(0, 2)) <= 12
+                  ? `오전 ${extractOnlyTime(eventEndTime)}`
+                  : `오후 ${extractOnlyTime(eventEndTime)}`
+                : `${gameCount}게임`}
+              {}
             </span>
           </div>
           <div className="w-full h-fit flex justify-start items-center gap-x-[6px]">

--- a/src/components/reservation-list/review/Review.tsx
+++ b/src/components/reservation-list/review/Review.tsx
@@ -9,6 +9,7 @@ export default function Review({
   eventDate,
   eventStartTime,
   eventEndTime,
+  gameCount,
   adultCount,
   teenagerCount,
   kidsCount,
@@ -25,6 +26,7 @@ export default function Review({
         eventDate={eventDate}
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
+        gameCount={gameCount}
         adultCount={adultCount}
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}

--- a/src/components/reservation-list/review/ReviewLowerSection.tsx
+++ b/src/components/reservation-list/review/ReviewLowerSection.tsx
@@ -2,6 +2,7 @@ import ReviewsFilledStar from '@public/svg/reviewFilledStar.svg';
 import ReviewsUnfilledStar from '@public/svg/reviewUnfilledStar.svg';
 import { ReviewLowerSectionProps } from 'types/reservation-list/review/ReservationListReviewPageTypes';
 import { cn } from '@utils/cn';
+import { formatDate } from '@utils/formatDate';
 
 export default function ReviewLowerSection({
   reservationUserName,
@@ -20,12 +21,16 @@ export default function ReviewLowerSection({
       <div className="w-full h-fit flex flex-col items-start gap-y-[6px]">
         <span className="title3 text-grey7">{reservationUserName}</span>
         <div className="flex justify-between items-center gap-x-[6px]">
-          <p className="caption2 text-grey4">{eventDate}</p>
+          <p className="caption2 text-grey4">
+            {formatDate(new Date(eventDate))}
+          </p>
           <p className="caption2 text-grey3">|</p>
           <p className="caption2 text-grey4">
-            {adultCount && `성인 ${adultCount}명 `}
-            {teenagerCount && `청소년 ${teenagerCount}명 `}
-            {kidsCount && `어린이 ${kidsCount}명 `}
+            {adultCount !== 0 && `성인 ${adultCount}명`}
+            {adultCount !== 0 && (teenagerCount || kidsCount) !== 0 && ', '}
+            {teenagerCount !== 0 && `청소년 ${teenagerCount}명`}
+            {teenagerCount !== 0 && kidsCount !== 0 && ', '}
+            {kidsCount !== 0 && `어린이 ${kidsCount}명`}
           </p>
         </div>
       </div>

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -88,4 +88,5 @@ export interface ReservationItemProps {
   reservationId: number;
   paymentId: string;
   memberName?: string;
+  reviewId: number;
 }

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -5,6 +5,7 @@ export interface HistoryInProgressItemProps {
   eventDate: string;
   eventStartTime: string;
   eventEndTime: string;
+  gameCount: number | null;
   adultCount?: number;
   teenagerCount?: number;
   kidsCount?: number;
@@ -74,6 +75,7 @@ export interface ReservationItemProps {
   date: string;
   startTime: string;
   endTime: string;
+  gameCount: number | null;
   price: number;
   // 아래의 속성은 각각 예약 확정, 예약 진행중, 거절됨, 취소됨, 체험 완료됨(리뷰는 아직), 체험 완료됨(리뷰도 끝남)을 의미
   status: 'CONFIRMED' | 'TBC' | 'DECLINED' | 'CANCELED' | 'DONE' | 'REVIEWED';


### PR DESCRIPTION
1. 리뷰 조회 (`/reservation-list/review/{reviewId}`) 페이지에 실제 리뷰 데이터를 연결
2. /search/result 페이지에 논로그인, 로그인 유저를 구분하여 각각의 api를 날리고 응답을 확인하여 `searchResult`, `originSearchResult` 상태에 연결함
3. HistoryUpperSection 컴포넌트에 게임당 예약인 경우에는 `12시 시작, 3게임` 양식으로 텍스트 수정
4. **/writing-review** 페이지에서 리뷰를 모두 작성하고 난 뒤(`isSubmitted` 속성이 true인 경우), 나타나는 날짜 포맷 양식의 수정