### PR TITLE
Feat/cancel : 결제 예약 취소 관련 구현

### DIFF
--- a/src/apis/portone/CustomPaymentError.ts
+++ b/src/apis/portone/CustomPaymentError.ts
@@ -1,0 +1,3 @@
+export interface CustomPaymentError extends Error {
+  paymentId: string;
+}

--- a/src/apis/portone/cancelPayment.ts
+++ b/src/apis/portone/cancelPayment.ts
@@ -30,6 +30,7 @@ const cancelPortOnePayment = async (paymentId: string) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `${process.env.NEXT_PUBLIC_PORTONE_API_SECRET_KEY}`,
       },
       body: JSON.stringify(cancleRequestData),
     }
@@ -44,6 +45,8 @@ const cancelPortOnePayment = async (paymentId: string) => {
   } else if (responseData.status === 'SUCCEEDED') {
     // 결제취소 성공 로직, 여기에서 백엔드로 우리 서비스 단의 예약 취소가 이루어지면 됨ㄴ
   }
+  // 일단 결제 응답만 반환한 뒤, redirect 페이지나 FullButton 컴포넌트에서 예약 취소를 진행
+  return responseData;
 };
 
 export default cancelPortOnePayment;

--- a/src/apis/portone/cancelPayment.ts
+++ b/src/apis/portone/cancelPayment.ts
@@ -18,10 +18,13 @@ interface cancelPortoneResponseProp {
   reason: string;
 }
 
-const cancelPortOnePayment = async (paymentId: string) => {
+const cancelPortOnePayment = async (
+  paymentId: string,
+  cancelReasonString: string
+) => {
   const cancleRequestData: cancelRequestProp = {
     storeId: process.env.NEXT_PUBLIC_PORTONE_STORE_ID as string,
-    reason: '고객의 TIG 사이트를 통한 체험 프로그램 예약 취소입니다', // 이거 말고 딱히 쓸 말이 없는듯? 아니면 고객한테 사유도 입력 받아야함
+    reason: cancelReasonString, // 이거 말고 딱히 쓸 말이 없는듯? 아니면 고객한테 사유도 입력 받아야함
   };
 
   const response = await fetch(

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -1,6 +1,7 @@
 import { instance } from '@apis/instance';
 import * as PortOne from '@portone/browser-sdk/v2';
 import { calculateTimeDiff } from '@utils/formatDate';
+import { CustomPaymentError } from './CustomPaymentError';
 
 export interface kakaoEasyPayBackendResponse {
   result: {
@@ -79,6 +80,13 @@ const handleKakaokEasyPay = async (
       memberId: reservationData.memberId,
     },
   });
+
+  // 포트원 결제 자체가 실패할 확률은 낮지만(아마 결제 자체가 안되긴 할듯), 확실하게 우리가 가진 paymentId로 결제 취소
+  if (response?.code) {
+    const paymentError = new Error('payment Failed') as CustomPaymentError;
+    paymentError.paymentId = customPaymentId;
+    throw paymentError;
+  }
 
   const result: kakaoEasyPayBackendResponse = await instance.post(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,

--- a/src/apis/portone/kakaoEasyPay.ts
+++ b/src/apis/portone/kakaoEasyPay.ts
@@ -29,7 +29,7 @@ const handleKakaokEasyPay = async (
   }
 ): Promise<kakaoEasyPayBackendResponse> => {
   const clubDataResonse = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/${reservationData.clubId}`
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/guest/${reservationData.clubId}`
   );
   const clubData = await clubDataResonse.json();
   // redirect로 보낼 query string임

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -30,7 +30,7 @@ const handleTossEasyPay = async (
   }
 ): Promise<tossEasyPayBackendResponse> => {
   const clubDataResonse = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/${reservationData.clubId}`
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/club/guest/${reservationData.clubId}`
   );
   const clubData = await clubDataResonse.json();
   const query = {

--- a/src/apis/portone/tossEasyPay.ts
+++ b/src/apis/portone/tossEasyPay.ts
@@ -2,6 +2,7 @@ import * as PortOne from '@portone/browser-sdk/v2';
 import makePaymentId from '@utils/makePaymentId';
 import { instance } from '@apis/instance';
 import { calculateTimeDiff } from '@utils/formatDate';
+import { CustomPaymentError } from './CustomPaymentError';
 
 export interface tossEasyPayBackendResponse {
   result: {
@@ -79,6 +80,13 @@ const handleTossEasyPay = async (
       memberId: reservationData.memberId,
     },
   });
+
+  // 포트원 결제 자체가 실패할 확률은 낮지만(아마 결제 자체가 안되긴 할듯), 확실하게 우리가 가진 paymentId로 결제 취소
+  if (response?.code) {
+    const paymentError = new Error('payment Failed') as CustomPaymentError;
+    paymentError.paymentId = customPaymentId;
+    throw paymentError;
+  }
 
   const result: tossEasyPayBackendResponse = await instance.post(
     `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,

--- a/src/apis/reservation-list/reservation/deleteUserSpecificReservation.ts
+++ b/src/apis/reservation-list/reservation/deleteUserSpecificReservation.ts
@@ -1,29 +1,17 @@
 import { useMutation } from '@tanstack/react-query';
 import { NoMeaningfulResultResponse } from 'types/response/response';
-import { error } from 'console';
+import { instance } from '@apis/instance';
 
 export const deleteUserSpecificReservation = async (
   reservationId: number
 ): Promise<NoMeaningfulResultResponse> => {
-  // api 엔드포인트는 추후 restful하게 수정 예정임
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/vi/reservation/cancel/${reservationId}`,
-    {
-      method: 'POST',
-      credentials: 'include',
-    }
+  return instance.post(
+    `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/reservation/cancel/${reservationId}`
   );
-
-  if (!response.ok) {
-    throw new Error(`Failed to cancel ${reservationId} reservation!`);
-  }
-
-  const data = await response.json();
-  return data;
 };
 
-export const useDeleteUserSpecificReservation = (reservationId: number) => {
+export const useDeleteUserSpecificReservation = () => {
   return useMutation({
-    mutationFn: () => deleteUserSpecificReservation(reservationId),
+    mutationFn: deleteUserSpecificReservation,
   });
 };

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -17,6 +17,7 @@ import { usePostReservation } from '@apis/payment/before/postReservation';
 import TigLoadingPage from '@components/all/TigLoadingPage';
 import { useRouter } from 'next/navigation';
 import cancelPortOnePayment from '@apis/portone/cancelPayment';
+import { useDeleteUserSpecificReservation } from '@apis/reservation-list/reservation/deleteUserSpecificReservation';
 
 export default function Page() {
   const [historyHeadState, setHistoryHeadState] = useState<
@@ -28,6 +29,9 @@ export default function Page() {
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [cancelPaymentId, setCancelPaymentId] = useState<string | null>(null);
+  const [cancelReservationId, setCancelReservationId] = useState<number | null>(
+    null
+  );
 
   const inProgressReservationList = reservationList
     ? reservationList.filter(
@@ -50,6 +54,7 @@ export default function Page() {
   );
 
   const { data, isError } = useGetReservationList();
+  const cancelReservationMutation = useDeleteUserSpecificReservation();
 
   const router = useRouter();
 
@@ -138,8 +143,9 @@ export default function Page() {
                     kidsCount={reservationItem.kidsCount}
                     reservationStatus={reservationItem.status}
                     reservationId={reservationItem.reservationId}
-                    paymentId={cancelPaymentId}
+                    paymentId={reservationItem.paymentId}
                     handleChangeCancelPaymentId={setCancelPaymentId}
+                    handleChangeCancelReservationId={setCancelReservationId}
                   />
                 ) : (
                   <HistoryEndItem
@@ -189,8 +195,9 @@ export default function Page() {
                     kidsCount={data.kidsCount}
                     reservationStatus={data.status}
                     reservationId={data.reservationId}
-                    paymentId={cancelPaymentId}
+                    paymentId={data.paymentId}
                     handleChangeCancelPaymentId={setCancelPaymentId}
+                    handleChangeCancelReservationId={setCancelReservationId}
                   />
                 ))}
               </main>
@@ -232,9 +239,21 @@ export default function Page() {
             button2Content="취소하기"
             title="예약을 취소하시겠습니까?"
             subTitle="예약 취소 시 수수료가 발생할 수 있습니다"
-            secondButtonFunc={() =>
-              cancelPortOnePayment(cancelPaymentId as string)
-            }
+            secondButtonFunc={() => {
+              cancelReservationMutation.mutate(cancelReservationId as number, {
+                onSuccess() {
+                  cancelPortOnePayment(
+                    cancelPaymentId as string,
+                    '고객에 의한 예약 취소입니다'
+                  );
+                  router.push('/reservation-list');
+                },
+              });
+              // cancelPortOnePayment(
+              //   cancelPaymentId as string,
+              //   '고객에 의한 예약 취소입니다.'
+              // );
+            }}
           />
         </div>
       )}

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -246,7 +246,7 @@ export default function Page() {
                     cancelPaymentId as string,
                     '고객에 의한 예약 취소입니다'
                   );
-                  router.push('/reservation-list');
+                  router.push('/');
                 },
               });
               // cancelPortOnePayment(

--- a/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/reservation/[reservationId]/page.tsx
@@ -63,6 +63,7 @@ export default async function page({
           couponDiscountPrice={0} // 백엔드에서 보내줄 필요가 있음
           cancelAvailableDate="2024년 08월 02일 13:00"
           status={data.result.status}
+          paymentId={data.result.paymentId}
         />
       </main>
       {/* <NavBar /> */}

--- a/src/app/payment/redirect/page.tsx
+++ b/src/app/payment/redirect/page.tsx
@@ -93,7 +93,8 @@ export default function PaymentRedirect({
     sendCheckingDataToBackend()
       .then((response) => response)
       .catch(async (error: CustomPaymentError) => {
-        cancelPortOnePayment(error.paymentId); // 백엔드 검증 로직 실패 시
+        const response = await cancelPortOnePayment(error.paymentId); // 백엔드 검증 로직 실패 시
+        console.log(response);
         router.replace('/');
       });
   }, []);

--- a/src/app/payment/redirect/page.tsx
+++ b/src/app/payment/redirect/page.tsx
@@ -5,6 +5,8 @@ import { instance } from '@apis/instance';
 import { useEffect } from 'react';
 import { usePostReservation } from '@apis/payment/before/postReservation';
 import TigLoadingPage from '@components/all/TigLoadingPage';
+import cancelPortOnePayment from '@apis/portone/cancelPayment';
+import { CustomPaymentError } from '@apis/portone/CustomPaymentError';
 
 // 백엔드에 예약 정보를 paymentI와 함께 넘기고 ok면 진짜 예약을 진행하고, 결제를 취소한다.
 export interface EasyPayBackendResponse {
@@ -39,6 +41,16 @@ export default function PaymentRedirect({
   };
 
   useEffect(() => {
+    async function cancelPaymentWithPaymentId(paymentId: string) {
+      const response = await cancelPortOnePayment(paymentId);
+      console.log(response);
+    }
+
+    // 결제 실패 시
+    if (searchParams.code) {
+      cancelPaymentWithPaymentId(searchParams.paymentId as string);
+    }
+
     async function sendCheckingDataToBackend() {
       const response: EasyPayBackendResponse = await instance.post(
         `${process.env.NEXT_PUBLIC_BACKEND_DOMAIN}/api/v1/pay/verification`,
@@ -68,10 +80,22 @@ export default function PaymentRedirect({
             },
           }
         );
+      } else {
+        // 백엔드에서의 검사 로직이 실패한 경우
+        const paymentError = new Error(
+          'Backend Verification Failed'
+        ) as CustomPaymentError;
+        paymentError.paymentId = searchParams.paymentId as string;
+        throw paymentError;
       }
     }
 
-    sendCheckingDataToBackend();
+    sendCheckingDataToBackend()
+      .then((response) => response)
+      .catch(async (error: CustomPaymentError) => {
+        cancelPortOnePayment(error.paymentId); // 백엔드 검증 로직 실패 시
+        router.replace('/');
+      });
   }, []);
   console.log(searchParams);
 

--- a/src/app/payment/redirect/page.tsx
+++ b/src/app/payment/redirect/page.tsx
@@ -42,7 +42,10 @@ export default function PaymentRedirect({
 
   useEffect(() => {
     async function cancelPaymentWithPaymentId(paymentId: string) {
-      const response = await cancelPortOnePayment(paymentId);
+      const response = await cancelPortOnePayment(
+        paymentId,
+        'portOne 결제 오류로 인한 취소입니다'
+      );
       console.log(response);
     }
 
@@ -93,7 +96,10 @@ export default function PaymentRedirect({
     sendCheckingDataToBackend()
       .then((response) => response)
       .catch(async (error: CustomPaymentError) => {
-        const response = await cancelPortOnePayment(error.paymentId); // 백엔드 검증 로직 실패 시
+        const response = await cancelPortOnePayment(
+          error.paymentId,
+          'Tig 백엔드 로직에서의 verification 오류로 인한 취소입니다'
+        ); // 백엔드 검증 로직 실패 시
         console.log(response);
         router.replace('/');
       });

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -20,6 +20,8 @@ import { usePostReservation } from '@apis/payment/before/postReservation';
 import makePaymentId from '@utils/makePaymentId';
 import { AxiosResponse } from 'axios';
 import { kakaoEasyPayBackendResponse } from '@apis/portone/kakaoEasyPay';
+import { CustomPaymentError } from '@apis/portone/CustomPaymentError';
+import cancelPortOnePayment from '@apis/portone/cancelPayment';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
@@ -223,6 +225,7 @@ export default function FullButton({
           }
         )
           .then((response) => {
+            console.log(response);
             if (response.resultCode === 200) {
               postReservationMutation.mutate(
                 {
@@ -251,9 +254,19 @@ export default function FullButton({
                   },
                 }
               );
+            } else {
+              // 백엔드에서의 검증 로직이 실패한 경우
+              const paymentError = new Error(
+                'Backend Verification Failed'
+              ) as CustomPaymentError;
+              paymentError.paymentId = customPaymentId;
+              throw paymentError;
             }
           })
-          .catch((error) => console.log(error))
+          .catch(async (error: CustomPaymentError) => {
+            const response = await cancelPortOnePayment(error.paymentId);
+            console.log(response);
+          })
           .finally(() => console.log('over'));
       }
 
@@ -313,9 +326,20 @@ export default function FullButton({
                   },
                 }
               );
+            } else {
+              // 백엔드에서의 검증 로직이 실패한 경우
+              const paymentError = new Error(
+                'Backend Verification Failed'
+              ) as CustomPaymentError;
+              paymentError.paymentId = customPaymentId;
+              throw paymentError;
             }
           })
-          .catch((error) => console.log(error))
+          .catch(async (error: CustomPaymentError) => {
+            const response = await cancelPortOnePayment(error.paymentId);
+
+            console.log(response);
+          })
           .finally(() => console.log('over'));
       }
 

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -264,7 +264,10 @@ export default function FullButton({
             }
           })
           .catch(async (error: CustomPaymentError) => {
-            const response = await cancelPortOnePayment(error.paymentId);
+            const response = await cancelPortOnePayment(
+              error.paymentId,
+              'Tig 백엔드 로직에서의 verification 오류로 인한 취소입니다'
+            );
             console.log(response);
             router.replace('/');
           })
@@ -337,7 +340,10 @@ export default function FullButton({
             }
           })
           .catch(async (error: CustomPaymentError) => {
-            const response = await cancelPortOnePayment(error.paymentId);
+            const response = await cancelPortOnePayment(
+              error.paymentId,
+              'Tig 백엔드 로직에서의 verification 오류로 인한 취소입니다'
+            );
             console.log(response);
             router.replace('/');
           })

--- a/src/components/all/FullButton.tsx
+++ b/src/components/all/FullButton.tsx
@@ -266,6 +266,7 @@ export default function FullButton({
           .catch(async (error: CustomPaymentError) => {
             const response = await cancelPortOnePayment(error.paymentId);
             console.log(response);
+            router.replace('/');
           })
           .finally(() => console.log('over'));
       }
@@ -337,8 +338,8 @@ export default function FullButton({
           })
           .catch(async (error: CustomPaymentError) => {
             const response = await cancelPortOnePayment(error.paymentId);
-
             console.log(response);
+            router.replace('/');
           })
           .finally(() => console.log('over'));
       }

--- a/src/components/reservation-list/HistoryInProgressItem.tsx
+++ b/src/components/reservation-list/HistoryInProgressItem.tsx
@@ -19,8 +19,10 @@ export default function HistoryInProgressItem({
   reservationId,
   paymentId,
   handleChangeCancelPaymentId,
+  handleChangeCancelReservationId,
 }: HistoryInProgressItemProps) {
   const setModalOpen = useModal((state) => state.setSelectedIsModalOpen);
+  console.log(paymentId);
 
   return (
     <Link
@@ -47,7 +49,9 @@ export default function HistoryInProgressItem({
             content="예약 취소"
             className="shadow-cancelButton"
             onClick={(ev) => {
+              // 상위 reservation-list 페이지에서 만든 cancelPaymentI와 cancelReservationId를 바꿔주고 모달을 띄운다.
               handleChangeCancelPaymentId(paymentId as string);
+              handleChangeCancelReservationId(reservationId);
               setModalOpen(true);
               console.log('예약취소 요청!');
               ev.stopPropagation();
@@ -73,6 +77,14 @@ export default function HistoryInProgressItem({
             content="예약 취소"
             clickTask="cancel-reservation"
             className="shadow-cancelButton"
+            onClick={(ev) => {
+              handleChangeCancelPaymentId(paymentId as string);
+              setModalOpen(true);
+              handleChangeCancelReservationId(reservationId);
+              console.log('예약취소 요청!');
+              ev.stopPropagation();
+              ev.preventDefault();
+            }}
           />
           <FullButton
             bgColor="primary_orange1"

--- a/src/components/reservation-list/reservation/HistoryDetail.tsx
+++ b/src/components/reservation-list/reservation/HistoryDetail.tsx
@@ -27,6 +27,7 @@ export default function HistoryDetail({
   couponDiscountPrice,
   cancelAvailableDate,
   status,
+  paymentId,
 }: ReservationDetailProps) {
   return (
     <div className="mt-[20px] mb-[80px] p-5 rounded-[10px] w-eightNineWidth h-fit flex flex-col items-center gap-y-[30px] bg-white shadow-myPageLogoutButton">
@@ -61,6 +62,7 @@ export default function HistoryDetail({
       <ReservationCancelSection
         cancelAvailableDate={cancelAvailableDate}
         status={status}
+        paymentId={paymentId}
       />
     </div>
   );

--- a/src/components/reservation-list/reservation/ReservationCancelSection.tsx
+++ b/src/components/reservation-list/reservation/ReservationCancelSection.tsx
@@ -1,22 +1,29 @@
 'use client';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useGetUserSpecificReservationInfo } from '@apis/reservation-list/reservation/getUserSpecificReservationInfo';
+import { useDeleteUserSpecificReservation } from '@apis/reservation-list/reservation/deleteUserSpecificReservation';
+import cancelPortOnePayment from '@apis/portone/cancelPayment';
 
 interface ReservationCancelProps {
   cancelAvailableDate: string;
   status: 'TBC' | 'CONFIRMED' | 'DECLINED' | 'CANCELED' | 'REVIEWED' | 'DONE';
+  paymentId: string;
 }
 
 export default function ReservationCancelSection({
   cancelAvailableDate,
   status,
+  paymentId,
 }: ReservationCancelProps) {
   const pathname = usePathname();
   const reservationId = pathname.split('/').at(-1);
+  const router = useRouter();
 
   const { data } = useGetUserSpecificReservationInfo(
     parseInt(reservationId as string)
   );
+
+  const cancelReservationMutation = useDeleteUserSpecificReservation();
 
   console.log(data);
 
@@ -29,7 +36,23 @@ export default function ReservationCancelSection({
         </span>
       </div>
       {status === 'TBC' || status === 'CONFIRMED' ? (
-        <button className="w-[72px] h-[33px] rounded-[4px] bg-white text-status_red1 body4 shadow-cancelButton">
+        <button
+          className="w-[72px] h-[33px] rounded-[4px] bg-white text-status_red1 body4 shadow-cancelButton"
+          onClick={() => {
+            cancelReservationMutation.mutate(
+              parseInt(reservationId as string),
+              {
+                onSuccess() {
+                  cancelPortOnePayment(
+                    paymentId,
+                    '고객에 의한 예약 취소입니다'
+                  );
+                  router.push('/reservation-list');
+                },
+              }
+            );
+          }}
+        >
           예약취소
         </button>
       ) : (

--- a/src/components/reservation-list/reservation/ReservationCancelSection.tsx
+++ b/src/components/reservation-list/reservation/ReservationCancelSection.tsx
@@ -47,7 +47,7 @@ export default function ReservationCancelSection({
                     paymentId,
                     '고객에 의한 예약 취소입니다'
                   );
-                  router.push('/reservation-list');
+                  router.push('/');
                 },
               }
             );

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -19,6 +19,7 @@ export interface HistoryInProgressItemProps {
   reservationId: number;
   paymentId: string | null;
   handleChangeCancelPaymentId: (paymentId: string) => void;
+  handleChangeCancelReservationId: (reservationId: number) => void;
 }
 
 export interface HistoryInAdminItemProps {
@@ -49,6 +50,7 @@ export interface HistoryComponentUpperSectionProps
     | 'reservationId'
     | 'handleChangeCancelPaymentId'
     | 'paymentId'
+    | 'handleChangeCancelReservationId'
   > {
   className?: string;
 }
@@ -56,7 +58,9 @@ export interface HistoryComponentUpperSectionProps
 export interface HistoryEndItemProps
   extends Omit<
     HistoryInProgressItemProps,
-    'handleChangeCancelPaymentId' | 'paymentId'
+    | 'handleChangeCancelPaymentId'
+    | 'paymentId'
+    | 'handleChangeCancelReservationId'
   > {
   reviewId?: number;
 }

--- a/src/types/reservation-list/reservation/ReservationDetailType.ts
+++ b/src/types/reservation-list/reservation/ReservationDetailType.ts
@@ -19,4 +19,5 @@ export interface ReservationDetailProps {
   couponDiscountPrice: number;
   cancelAvailableDate: string;
   status: 'TBC' | 'CONFIRMED' | 'DECLINED' | 'CANCELED' | 'REVIEWED' | 'DONE';
+  paymentId: string;
 }


### PR DESCRIPTION
예약 취소 기능을 구현했는데 핵심은 다음과 같음

1. portOne 자체에서 결제가 안된 경우, 사실 이때에는 금액 자체가 안 빠져나갔을 거 같긴한데 그래도 혹시 몰라 확실하게 하기 위해 paymentId로 결제 취소 요청을 보내긴 함.
2. 백엔드의 verification 엔드포인트 로직에서 오류를 반환한 경우(즉, 위조된 예약 요청인 경우를 의미), 이때에도 결제 및 예약 취소. 이때에는 아직 tig 예약 자체가 들어간게 아니기에 결제 취소만 portOne 측에 하면 됨
3. 위의 개념들은 에러가 발생하면 error를 throw하고 이를 catch해서 반영함. mobile 환경 redirect 페이지에도 이 로직을 반영해주었음
4. 결제 취소 사유를 portone에 reason 필드로 보내주는데, portOne 결제 오류(위에서 말했지만 사실상 없는 케이스 같긴함), 백엔드 verification 오류, 고객의 취소 케이스를 구분해서 취소 사유를 작성해주었음 -> 추후 TIG 서비스 로그를 까볼 때 유용할 것 같아서.


club 내역 조회하는 api 엔드 포인트(guest 뭐시기)를 새롭게 반영해주었음.

`/reservation-list` 페이지에서 `TBC`, `CONFIRMED` 상태인 경우 취소를 할때 해당 페이지의 상태로 cancelPaymentId, cancelReservationId 를 만들어주고 FullButton으로 내려주었음. 그러면 사용자가 예약 취소 버튼을 누르면 해당 상태들이 관련된 paymentId, reservationId로 바뀌고 그 다음에 모달이 뜸
모달은 `/reservation-list`페이지와 동일 레벨에 있기에 해당 상태를 공유받을 수 있어 취소할 때 이를 가지고 함. 우선 tig 사이트에서의 예약을 취소하고 성공하면 `onSuccess` 함수 설정을 통해 portOne 결제 취소를 해줬음.
이 기능을 `/reservation-list/reservation/{reservationid}` 페이지의 예약 취소버튼이 active한 상태일 때에도 적용해줬음.
