### PR TITLE
Feat/recent search

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    domains: ['t1.kakaocdn.net'],
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,

--- a/src/apis/club/getSpeicificClubInfoForLogin.ts
+++ b/src/apis/club/getSpeicificClubInfoForLogin.ts
@@ -37,5 +37,6 @@ export const useGetSpecificClubInfoForLogin = (clubId: string) => {
   return useQuery({
     queryKey: ['specificClubInfoForLogin', clubId],
     queryFn: () => getSpecificClubInfoForLogin(clubId),
+    refetchOnMount: 'always',
   });
 };

--- a/src/apis/djemalsvpdlwl/getTBCReservation.ts
+++ b/src/apis/djemalsvpdlwl/getTBCReservation.ts
@@ -1,8 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
-import { ReservationItemProps } from 'types/reservation-list/ReservationListPageTypes';
 
+export interface TBCReservationItemProps {
+  adultCount: number;
+  teenagerCount: number;
+  kidsCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  gameCount: number | null;
+  price: number;
+  // 아래의 속성은 각각 예약 확정, 예약 진행중, 거절됨, 취소됨, 체험 완료됨(리뷰는 아직), 체험 완료됨(리뷰도 끝남)을 의미
+  status: 'CONFIRMED' | 'TBC' | 'DECLINED' | 'CANCELED' | 'DONE' | 'REVIEWED';
+  memberId: number | null;
+  clubId: number | null;
+  type: any; // any로 된 것은 추후 수정
+  businessHours: any;
+  clubName: string;
+  clubAddress: string;
+  reservationId: number;
+  paymentId: string;
+  memberName?: string;
+  clubPhoneNumber: string;
+  reviewId: number;
+}
 export interface TBCReservationListResponse {
-  result: ReservationItemProps[];
+  result: TBCReservationItemProps[];
   resultCode: number;
   resultMsg: string;
 }

--- a/src/apis/search/deleteSearchAllLogs.ts
+++ b/src/apis/search/deleteSearchAllLogs.ts
@@ -1,0 +1,17 @@
+import { instance } from '@apis/instance';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserInfoResponse } from 'types/response/response';
+
+const deleteSearchAllLogs = async (): Promise<UserInfoResponse> => {
+  return instance.delete(`/api/v1/search/logs/all`);
+};
+
+export const useDeleteSearchAllLogs = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteSearchAllLogs,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recentSearch'] });
+    },
+  });
+};

--- a/src/apis/search/deleteSearchLog.ts
+++ b/src/apis/search/deleteSearchLog.ts
@@ -1,0 +1,17 @@
+import { instance } from '@apis/instance';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { UserInfoResponse } from 'types/response/response';
+
+const deleteSearchLog = async (log: string): Promise<UserInfoResponse> => {
+  return instance.delete(`/api/v1/search/logs?target=${log}`);
+};
+
+export const useDeleteSearchLog = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteSearchLog,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['recentSearch'] });
+    },
+  });
+};

--- a/src/apis/search/getLoginUserSearchedResult.ts
+++ b/src/apis/search/getLoginUserSearchedResult.ts
@@ -27,5 +27,6 @@ export const useGetLoginUserSearchedResult = (search: string) => {
       const searchParam = queryKey[1] as string; // search 인수 추출
       return getLoginUserSearchedResult(searchParam);
     },
+    refetchOnMount: 'always',
   });
 };

--- a/src/apis/search/getRecentSearch.ts
+++ b/src/apis/search/getRecentSearch.ts
@@ -1,0 +1,15 @@
+import { instance } from '@apis/instance';
+import { useQuery } from '@tanstack/react-query';
+import { RecentSearchResponse } from 'types/response/response';
+
+const getRecentSearch = async (): Promise<RecentSearchResponse> => {
+  return instance.get('/api/v1/search/logs');
+};
+
+export const useGetRecentSearch = () => {
+  return useQuery({
+    queryKey: ['recentSearch'],
+    queryFn: getRecentSearch,
+    refetchOnMount: 'always',
+  });
+};

--- a/src/app/(NavBarCommonLayout)/search/result/SearchResult.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/SearchResult.tsx
@@ -46,8 +46,9 @@ export function SearchResult() {
     Object.fromEntries(searchParams.entries());
   const parsedDate = parse(date, "yyyy-MM-dd'T'HH:mm:ss", new Date());
   const formattedDate = formatDate(parsedDate, 'M.dd (EEE)', { locale: ko });
-  const loginUserSearchResult = useGetLoginUserSearchedResult(search);
-  const UnLoginUserSearchResult = useGetUnLoginUserSearchedResult(search);
+  const { data: loginUserSearchResult } = useGetLoginUserSearchedResult(search);
+  const { data: unLoginUserSearchResult } =
+    useGetUnLoginUserSearchedResult(search);
 
   useEffect(() => {
     if (selectedOption === '추천순') {
@@ -88,27 +89,28 @@ export function SearchResult() {
   useEffect(() => {
     if (localStorage.getItem('accessToken')) {
       console.log('로그인 유저');
+      console.log(loginUserSearchResult);
       setCurrentLocation({
-        latitude: loginUserSearchResult.data?.result.avgLatitude || 37.55527,
-        longitude: loginUserSearchResult.data?.result.avgLongitude || 126.9366,
+        latitude: loginUserSearchResult?.result.avgLatitude || 37.55527,
+        longitude: loginUserSearchResult?.result.avgLongitude || 126.9366,
       });
-      setSearchResult(loginUserSearchResult.data?.result.searchList || []);
+      setSearchResult(loginUserSearchResult?.result.searchList || []);
       setOriginalSearchResult(
-        loginUserSearchResult.data?.result.searchList || []
+        loginUserSearchResult?.result.searchList || []
       );
     } else {
       console.log('비로그인 유저');
       setCurrentLocation({
-        latitude: UnLoginUserSearchResult.data?.result.avgLatitude || 37.55527,
+        latitude: unLoginUserSearchResult?.result.avgLatitude || 37.55527,
         longitude:
-          UnLoginUserSearchResult.data?.result.avgLongitude || 126.9366,
+          unLoginUserSearchResult?.result.avgLongitude || 126.9366,
       });
-      setSearchResult(UnLoginUserSearchResult.data?.result.searchList || []);
+      setSearchResult(unLoginUserSearchResult?.result.searchList || []);
       setOriginalSearchResult(
-        UnLoginUserSearchResult.data?.result.searchList || []
+        unLoginUserSearchResult?.result.searchList || []
       );
     }
-  }, [loginUserSearchResult.data, UnLoginUserSearchResult.data, searchResult]);
+  }, [loginUserSearchResult, unLoginUserSearchResult, searchResult]);
 
   const selectedTab = useTab((state) => state.selectedTab);
 

--- a/src/app/(NavBarCommonLayout)/wishlist/page.tsx
+++ b/src/app/(NavBarCommonLayout)/wishlist/page.tsx
@@ -107,7 +107,7 @@ export default function Page() {
           ) : (
             <div className="flex w-full h-full justify-center items-center pt-[120px]  title2 text-grey7">
               <NoneResultUI
-                message="위시리스트에 담긴 곳이 없어요"
+                message="위시리스트에 담긴 곳이 없어요."
                 subMessage="마음에 드는 장소를 찾아 담아보세요!"
               />
             </div>

--- a/src/app/djemalsvpdlwl/manage-reservation/page.tsx
+++ b/src/app/djemalsvpdlwl/manage-reservation/page.tsx
@@ -22,6 +22,7 @@ export default function Page() {
             reservationId={reservationInfo.reservationId}
             paymentId={reservationInfo.paymentId}
             memberName={reservationInfo.memberName || ''}
+            clubPhoneNumber={reservationInfo.clubPhoneNumber}
           />
         ))}
     </main>

--- a/src/app/djemalsvpdlwl/manage-reservation/page.tsx
+++ b/src/app/djemalsvpdlwl/manage-reservation/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 import { useGetTBCReservationList } from '@apis/djemalsvpdlwl/getTBCReservation';
 import HistoryInAdminItem from '@components/djemalsvpdlwl/HistoryAdminItem';
 
@@ -21,6 +21,7 @@ export default function Page() {
             reservationStatus={reservationInfo.status}
             reservationId={reservationInfo.reservationId}
             paymentId={reservationInfo.paymentId}
+            memberName={reservationInfo.memberName || ''}
           />
         ))}
     </main>

--- a/src/components/detail-page/DetailInfoCard.tsx
+++ b/src/components/detail-page/DetailInfoCard.tsx
@@ -26,7 +26,7 @@ interface DetailInfoCardProps {
   price: number;
   businessHours: string;
   phoneNumber: string;
-  snsLink: string;
+  snsLink: string | null;
 }
 
 // eslint-disable-next-line react/display-name
@@ -44,7 +44,7 @@ export const DetailInfoCard = forwardRef<HTMLDivElement, DetailInfoCardProps>(
       type,
       price,
       phoneNumber,
-      snsLink,
+      snsLink = '/',
     },
     ref
   ) => {
@@ -114,7 +114,7 @@ export const DetailInfoCard = forwardRef<HTMLDivElement, DetailInfoCardProps>(
           </div>
           <div className="flex gap-2">
             <SnsSVG />
-            <Link href={snsLink}>{snsLink}</Link>
+            {snsLink ? <Link href={snsLink}>{snsLink}</Link> : <p>-</p>}
           </div>
         </div>
       </section>

--- a/src/components/djemalsvpdlwl/HistoryAdminItem.tsx
+++ b/src/components/djemalsvpdlwl/HistoryAdminItem.tsx
@@ -11,6 +11,7 @@ export default function HistoryInAdminItem({
   imageUrl,
   clubName,
   clubAddress,
+  memberName,
   eventDate,
   eventStartTime,
   eventEndTime,
@@ -22,15 +23,14 @@ export default function HistoryInAdminItem({
 }: HistoryInAdminItemProps) {
   const { mutate: confirmReservation } = useConfirmReservation();
   const { mutate: declineReservation } = useDeclineReservation();
-
   return (
     <Link
       href={`/reservation-list/reservation/${reservationId}`}
-      className="w-eightNineWidth h-fit p-5 gap-y-6 flex flex-col justify-between items-center shadow-myPageLogoutButton rounded-[10px]"
+      className="w-eightNineWidth h-fit p-5 gap-y-3 flex flex-col justify-between items-center shadow-myPageLogoutButton rounded-[10px]"
     >
       <HistoryComponentUpperSection
         clubName={clubName}
-        clubAddress={clubAddress}
+        clubAddress={`reservation id: ${String(reservationId)}`}
         eventDate={eventDate}
         eventStartTime={eventStartTime}
         eventEndTime={eventEndTime}
@@ -39,6 +39,7 @@ export default function HistoryInAdminItem({
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}
       />
+        <p className='body3'>예약자 이름: {memberName}</p>
       <div className="w-full h-fit flex gap-[10px]">
         <FullButton
           bgColor="white"

--- a/src/components/djemalsvpdlwl/HistoryAdminItem.tsx
+++ b/src/components/djemalsvpdlwl/HistoryAdminItem.tsx
@@ -19,6 +19,7 @@ export default function HistoryInAdminItem({
   teenagerCount,
   kidsCount,
   reservationId,
+  clubPhoneNumber,
   paymentId,
 }: HistoryInAdminItemProps) {
   const { mutate: confirmReservation } = useConfirmReservation();
@@ -26,7 +27,7 @@ export default function HistoryInAdminItem({
   return (
     <Link
       href={`/reservation-list/reservation/${reservationId}`}
-      className="w-eightNineWidth h-fit p-5 gap-y-3 flex flex-col justify-between items-center shadow-myPageLogoutButton rounded-[10px]"
+      className="w-eightNineWidth h-fit p-5 gap-y-2 flex flex-col justify-between items-center shadow-myPageLogoutButton rounded-[10px]"
     >
       <HistoryComponentUpperSection
         clubName={clubName}
@@ -39,7 +40,8 @@ export default function HistoryInAdminItem({
         teenagerCount={teenagerCount}
         kidsCount={kidsCount}
       />
-        <p className='body3'>예약자 이름: {memberName}</p>
+        <p className='body4'>예약자 이름: {memberName}</p>
+        <p className='body4'>업체 번호: {clubPhoneNumber}</p>
       <div className="w-full h-fit flex gap-[10px]">
         <FullButton
           bgColor="white"

--- a/src/components/mypage/My.tsx
+++ b/src/components/mypage/My.tsx
@@ -3,13 +3,25 @@ import MyProfileDefaultImage from '@public/svg/myProfileDefaultImage.svg';
 import ProfileInformation from './ProfileInformation';
 import ToastUI from './ToastUI';
 import useModal from '@store/modalStore';
+import { useGetUserInfo } from '@apis/mypage/getUserInfo';
+import Image from 'next/image';
+import TigLoadingPage from '@components/all/TigLoadingPage';
 
 export default function My() {
   const setIsOpen = useModal((state) => state.setSelectedIsModalOpen);
+  const { data, isSuccess } = useGetUserInfo();
+  if (!isSuccess) return <TigLoadingPage />;
   return (
     <div className="w-full flex flex-col items-center absolute top-[68px] pt-5">
       <div className="w-eightNineWidth mypageWidth h-fit flex flex-col items-center gap-y-[30px] mb-[30px]">
-        <MyProfileDefaultImage />
+        {/* <MyProfileDefaultImage /> */}
+        <Image
+          src={data.result.profileImage}
+          alt="프로필 이미지"
+          className="rounded-[50%]"
+          width={80}
+          height={80}
+        />
         <ProfileInformation />
       </div>
       <div className="w-full border-[1px] border-grey2 mb-[30px]"></div>

--- a/src/components/mypage/ProfileInformationItem.tsx
+++ b/src/components/mypage/ProfileInformationItem.tsx
@@ -108,6 +108,11 @@ export default function ProfileInformationItem({
     }
   };
 
+  const handleBlur = () => {
+    setInputBoxEditStage(1);
+    setInputData(inputValue);
+  }
+
   return (
     <div className={cn('w-full h-fit flex items-center', {})}>
       <span className="caption2 text-grey5 w-[84px]">{labelName}</span>
@@ -132,6 +137,7 @@ export default function ProfileInformationItem({
             onChange={handleChangeInputData}
             ref={inputRef}
             onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
             className="body4 w-[150px] text-grey7 shadow-writingReviewInput flex rounded-[4px] justify-start items-center pt-2 pl-2 pb-2"
           />
         )}

--- a/src/components/payment/before/CouponPage.tsx
+++ b/src/components/payment/before/CouponPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import useCoupon from '@store/couponStore';
+import useCoupon, { useSelectedCouponNumber } from '@store/couponStore';
 import { useState, useEffect } from 'react';
 import Header from '@components/all/Header';
 import { cn } from '@utils/cn';
@@ -15,6 +15,7 @@ interface couponDetail {
 
 interface couponItemDetail extends couponDetail {
   selectedCouponNumber: number;
+  handleCancelCoupon: (st: boolean) => void;
   handleClickCoupon: (st: number) => void;
   couponIndex: number;
 }
@@ -22,7 +23,13 @@ interface couponItemDetail extends couponDetail {
 export default function CouponPage() {
   const couponList = useCoupon((state) => state.couponList);
   const setCouponList = useCoupon((state) => state.setCouponList);
-  const [selectedCouponNumber, setselectedCouponNumber] = useState<number>(-1);
+  const [isCouponCancel, setIsCouponCancel] = useState<boolean>(false);
+  const selectedCouponNumber = useSelectedCouponNumber(
+    (state) => state.selectedCouponNumber
+  );
+  const setSelectedCouponNumber = useSelectedCouponNumber(
+    (state) => state.setSelectedCouponNumber
+  );
 
   useEffect(() => {
     // 원래는 백엔드로부터 쿠폰 리스트들을 받아오는 로직이 존재
@@ -83,19 +90,34 @@ export default function CouponPage() {
             isValid={coupon.isValid}
             couponExpireDate={coupon.couponExpireDate}
             selectedCouponNumber={selectedCouponNumber}
-            handleClickCoupon={setselectedCouponNumber}
+            handleClickCoupon={setSelectedCouponNumber}
+            handleCancelCoupon={setIsCouponCancel}
             couponIndex={index}
           />
         ))}
       </div>
       {selectedCouponNumber === -1 ? (
-        <FullButton
-          size="lg"
-          color="white"
-          bgColor="grey3"
-          content="적용하기"
-          className="absolute bottom-[30px] !w-eightNineWidth"
-        />
+        isCouponCancel ? (
+          <FullButton
+            size="lg"
+            color="white"
+            bgColor="primary_orange1"
+            content="적용 취소하기"
+            className="absolute bottom-[30px] !w-eightNineWidth"
+            clickTask="apply-coupon"
+            sendingData={{
+              selectedCouponPrice: 0,
+            }}
+          />
+        ) : (
+          <FullButton
+            size="lg"
+            color="white"
+            bgColor="grey3"
+            content="적용하기"
+            className="absolute bottom-[30px] !w-eightNineWidth"
+          />
+        )
       ) : (
         <FullButton
           size="lg"
@@ -121,8 +143,10 @@ function CouponItem({
   couponExpireDate,
   selectedCouponNumber,
   handleClickCoupon,
+  handleCancelCoupon,
   couponIndex,
 }: couponItemDetail) {
+  console.log(selectedCouponNumber, couponIndex);
   return (
     <section
       className={cn(
@@ -133,7 +157,13 @@ function CouponItem({
       )}
       onClick={() => {
         if (isValid) {
-          handleClickCoupon(couponIndex);
+          if (selectedCouponNumber === couponIndex) {
+            handleClickCoupon(-1);
+            handleCancelCoupon(true);
+          } else {
+            handleClickCoupon(couponIndex);
+            handleCancelCoupon(false);
+          }
         } else {
           return;
         }

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -9,11 +9,20 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import useSearchModalInput from '@store/searchModalInputStore';
 import { useSearchInputInfo } from '@store/searchInfoStore';
+import { useGetRecentSearch } from '@apis/search/getRecentSearch';
+import { RecentSearches } from 'types/response/response';
+import { useDeleteSearchLog } from '@apis/search/deleteSearchLog';
+import { useDeleteSearchAllLogs } from '@apis/search/deleteSearchAllLogs';
 
-const DUMMYRECENTSEARCH = ['신촌', '볼링', '탁구', '당구', '잠실'];
+const DUMMYRECENTSEARCH: RecentSearches[] = [{ name: '신촌', createdAt: '1' }];
 
 export default function SearchModal() {
-  const [recentSearch, setRecentSearch] = useState(DUMMYRECENTSEARCH);
+  const { data } = useGetRecentSearch();
+  const { mutate: deleteSearchLog } = useDeleteSearchLog();
+  const { mutate: deleteSearchAllLogs } = useDeleteSearchAllLogs();
+  console.log(data);
+  const [recentSearch, setRecentSearch] =
+    useState<RecentSearches[]>(DUMMYRECENTSEARCH);
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const isModalOpen = useSearchModal(
@@ -27,10 +36,12 @@ export default function SearchModal() {
 
   const deleteHandler = (idx: number) => () => {
     setRecentSearch((prev) => prev.filter((_, i) => i !== idx));
+    deleteSearchLog(recentSearch[idx].name);
   };
 
   const deleteAllHanler = () => {
     setRecentSearch([]);
+    deleteSearchAllLogs();
   };
 
   useEffect(() => {
@@ -44,9 +55,11 @@ export default function SearchModal() {
   }, [isModalOpen]);
 
   useEffect(() => {
-    // 최근 검색어 get 요청
-    setRecentSearch(DUMMYRECENTSEARCH);
-  }, []);
+    if (data) {
+      setRecentSearch(data.result);
+      console.log(data.result);
+    }
+  }, [data]);
 
   const inputHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue({ ...inputValue, searchValue: e.target.value });
@@ -99,7 +112,7 @@ export default function SearchModal() {
       </div>
       {recentSearch.map((search, idx) => (
         <div
-          key={idx + search}
+          key={idx + search.name}
           className="w-full flex justify-between items-center gap-[10px] px-5"
         >
           <p
@@ -110,7 +123,7 @@ export default function SearchModal() {
               );
             }}
           >
-            {search}
+            {search.name}
           </p>
           <SearchCloseSVG
             className="cursor-pointer"

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -119,7 +119,7 @@ export default function SearchModal() {
             className="body2 cursor-pointer"
             onClick={() => {
               router.push(
-                `/search/result?location=${search}&date=2024-07-11T00:00:00&adultCount=5&teenagerCount=5&kidsCount=5`
+                `/search/result?search=${search.name}&date=${search.createdAt.slice(0,19)}&adultCount=1&teenagerCount=0&kidsCount=0`
               );
             }}
           >

--- a/src/components/search/result/ResultCard.tsx
+++ b/src/components/search/result/ResultCard.tsx
@@ -7,7 +7,7 @@ import FillHeartSVG from '@public/svg/fillHeart.svg';
 import DiscountSVG from '@public/svg/discount.svg';
 import Link from 'next/link';
 import { cn } from '@utils/cn';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useDeleteFromWishList } from '@apis/wishlist/deleteFromWishlist';
 import { useAddToWishList } from '@apis/wishlist/addToWishList';
@@ -30,6 +30,7 @@ export default function ResultCard({
 }: ResultCardProps) {
   const router = useRouter();
   const [isHeartClicked, setIsHeartClicked] = useState(isHeart);
+  console.log(isHeartClicked);
   const { mutate: deleteFromWishList } = useDeleteFromWishList();
   const { mutate: addToWishList } = useAddToWishList();
   const handleFillHeartClick = (e: React.MouseEvent<SVGSVGElement>) => {
@@ -49,6 +50,11 @@ export default function ResultCard({
     addToWishList(clubId || 0);
     setIsHeartClicked(true);
   };
+
+  useEffect(() => {
+    setIsHeartClicked(isHeart);
+  }, [isHeart]);
+
   return (
     <section
       onClick={() => {

--- a/src/store/couponStore.ts
+++ b/src/store/couponStore.ts
@@ -28,3 +28,15 @@ export const useIsCouponPageOpen = create<isCouponPageOpenProps>((set) => ({
   isCouponPageOpen: false,
   setIsCouponPageOpen: (status) => set({ isCouponPageOpen: status }),
 }));
+
+interface selectedCouponNumberProps {
+  selectedCouponNumber: number;
+  setSelectedCouponNumber: (status: number) => void;
+}
+
+export const useSelectedCouponNumber = create<selectedCouponNumberProps>(
+  (set) => ({
+    selectedCouponNumber: -1,
+    setSelectedCouponNumber: (status) => set({ selectedCouponNumber: status }),
+  })
+);

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -25,6 +25,7 @@ export interface HistoryInAdminItemProps {
   imageUrl?: string;
   clubName: string;
   clubAddress: string;
+  memberName: string;
   eventDate: string;
   eventStartTime: string;
   eventEndTime: string;

--- a/src/types/reservation-list/ReservationListPageTypes.ts
+++ b/src/types/reservation-list/ReservationListPageTypes.ts
@@ -26,6 +26,7 @@ export interface HistoryInAdminItemProps {
   clubName: string;
   clubAddress: string;
   memberName: string;
+  clubPhoneNumber: string;
   eventDate: string;
   eventStartTime: string;
   eventEndTime: string;

--- a/src/types/response/response.ts
+++ b/src/types/response/response.ts
@@ -85,3 +85,13 @@ export interface noDataServerErrorResponse {
   errors: any;
   reason: string; // 못 찾은 이유를 백엔드에서 보내줌
 }
+
+export interface RecentSearches {
+  name: string;
+  createdAt: string;
+}
+export interface RecentSearchResponse {
+  result: RecentSearches[];
+  resultCode: number;
+  resultMsg: string;
+}


### PR DESCRIPTION
## 🕹️ 개요
최근검색 API 연동, 어드민페이지 변경, 디자인 QA 적용

## 🔎 작업 사항
- 최근검색 API 받아오기, 한 개씩 삭제, 전체 삭제 API 연동
- 어드민 페이지 카드 내 정보 변경
- 검색결과 페이지, 상세페이지 좋아요가 tanstack-qeury의 캐싱때문에 적용되지 않던 버그 해결
- 디자인 QC
  1. 위시리스트 필터링 시 문구 수정
  2. 마이페이지 infoItem blur시 상태 초기화
  3. 쿠폰 해제기능 추가
 
## 📋 작업 브랜치
Feat/recent search