### PR TITLE
Fix/trivial3

### DIFF
--- a/src/app/payment/before/[clubId]/page.tsx
+++ b/src/app/payment/before/[clubId]/page.tsx
@@ -45,6 +45,11 @@ export default function Page({
   const reservationStageState = useReservationStage(
     (state) => state.reservationStage
   );
+
+  const setReservationStageState = useReservationStage(
+    (state) => state.setReservationStage
+  );
+
   const isCouponPageOpen = useIsCouponPageOpen(
     (state) => state.isCouponPageOpen
   );
@@ -177,7 +182,10 @@ export default function Page({
   ]);
 
   useEffect(() => {
-    return () => setSelectedIsModalOpen(false);
+    return () => {
+      setSelectedIsModalOpen(false)
+      setReservationStageState(1);
+    }
   }, []);
 
   return !isCouponPageOpen ? (

--- a/src/app/reservation/game/[companyId]/page.tsx
+++ b/src/app/reservation/game/[companyId]/page.tsx
@@ -45,7 +45,7 @@ export default function Page({ params }: { params: { companyId: string } }) {
       <ResPeopleCountCard />
       <GameCountCard />
       <RequestCard />
-      <MakeResButtonCard clubName={clubName} address={address} />
+      <MakeResButtonCard clubName={clubName} address={address} clubStartTime={startTime}/>
       <Toaster position="bottom-center" containerStyle={{ bottom: '90px' }} />
     </main>
   );

--- a/src/app/reservation/time/[companyId]/page.tsx
+++ b/src/app/reservation/time/[companyId]/page.tsx
@@ -22,6 +22,7 @@ const DUMMYPRICE = '10,000';
 export default function Page({ params }: { params: { companyId: string } }) {
   const { data, isSuccess } = useGetClubResInfo(params.companyId);
   const [startTime, setStartTime] = useState('');
+  console.log('startTime', startTime);
   const [endTime, setEndTime] = useState('');
   const [clubName, setClubName] = useState('');
   const [address, setAddress] = useState('');
@@ -50,7 +51,7 @@ export default function Page({ params }: { params: { companyId: string } }) {
       <RestimeCard startTime={startTime} endTime={endTime} />
       <ResPeopleCountCard />
       <RequestCard />
-      <MakeResButtonCard clubName={clubName} address={address} />
+      <MakeResButtonCard clubName={clubName} address={address} clubStartTime={startTime}/>
       <Toaster position="bottom-center" containerStyle={{ bottom: '90px' }} />
     </main>
   );

--- a/src/components/mypage/ProfileInformationItem.tsx
+++ b/src/components/mypage/ProfileInformationItem.tsx
@@ -160,6 +160,7 @@ export default function ProfileInformationItem({
         )}
         {inputBoxEditStage === 2 && (
           <button
+            onMouseDown={(e) => e.preventDefault()}
             className="w-fit h-fit rounded-md title4 text-white bg-primary_orange1 px-[14px] py-[8px]"
             onClick={handleSubmit}
           >

--- a/src/components/reservation/MakeResButtonCard.tsx
+++ b/src/components/reservation/MakeResButtonCard.tsx
@@ -5,6 +5,7 @@ import {
   useGameReservationStore,
   useTimeReservationStore,
 } from '@store/makeReservationInfo';
+import { convertToNextDayIfNextDay } from '@utils/formatDate';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
@@ -12,9 +13,11 @@ import toast from 'react-hot-toast';
 export default function MakeResButtonCard({
   clubName,
   address,
+  clubStartTime,
 }: {
   clubName: string;
   address: string;
+  clubStartTime: string;
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -62,9 +65,15 @@ export default function MakeResButtonCard({
         handleWrongSubmit('GAME');
         return; // clubId가 undefined, null, ''과 같은 경우
       }
+      const calculateDate = convertToNextDayIfNextDay(
+        gameResInfo.startTime?.slice(11, 16) || '',
+        clubStartTime,
+        gameResInfo.date
+      );
+
       const query = {
         gameType: 'GAME',
-        date: gameResInfo.date,
+        date: calculateDate,
         startTime: gameResInfo.startTime,
         gameCount: String(gameResInfo.gameCount),
         request: gameResInfo.request,
@@ -90,9 +99,15 @@ export default function MakeResButtonCard({
         handleWrongSubmit('TIME');
         return; // clubId가 undefined, null, ''과 같은 경우
       }
+      const calculateDate = convertToNextDayIfNextDay(
+        timeResInfo.startTime?.slice(11, 16) || '',
+        clubStartTime,
+        timeResInfo.date
+      );
+
       const query = {
         gameType: 'TIME',
-        date: timeResInfo.date,
+        date: calculateDate,
         startTime: timeResInfo.startTime,
         endTime: timeResInfo.endTime,
         request: timeResInfo.request,

--- a/src/components/reservation/TimeSelectCard.tsx
+++ b/src/components/reservation/TimeSelectCard.tsx
@@ -22,16 +22,23 @@ export default function TimeSelectCard({
   onClick,
   idx,
 }: TimeSelectCardProps) {
-  console.log(isEven, isLast)
   return (
     <div className="flex flex-col w-[30px] cursor-pointer">
       <p
         className={cn('caption2 text-white pb-[6px]', {
-          'text-grey4': isAfternoon || isFirst,
-          invisible: !(isAfternoon || isFirst),
+          'text-grey4': isAfternoon || isFirst || time === '00:00',
+          invisible: !(isAfternoon || isFirst || time === '00:00'),
         })}
       >
-        {isAfternoon ? '오후' : isFirst ? '오전' : 'ㅇㅇ'}
+        {isAfternoon
+          ? '오후'
+          : isFirst
+          ? parseInt(time.slice(0, 2)) < 12
+            ? '오전'
+            : '오후'
+          : time === '00:00'
+          ? '오전'
+          : 'ㅇㅇ'}
       </p>
       <p
         className={cn('body4 text-white pb-[6px]', {
@@ -41,9 +48,11 @@ export default function TimeSelectCard({
       >
         {time.slice(3) === '00' ? `${time.slice(0, 2)}시` : 'ㅇㅇ'}
       </p>
-      <div className={cn("h-[4px]",{
-        'border-r border-r-grey4': !isLast && isEven
-      })}></div>
+      <div
+        className={cn('h-[4px]', {
+          'border-r border-r-grey4': !isLast && isEven,
+        })}
+      ></div>
       <button
         className={cn(
           'w-[30px] h-[34px] bg-primary_orange2 border-r border-white',

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 export const formatDate = (date: Date): string => {
   const day = String(date.getDate()).padStart(2, '0');
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -63,4 +65,29 @@ export const extractReservationMoment = (timestamp: string): string => {
   let formattedTime = `${year}.${month}.${day} (${dayOfWeek}) ${hours}:${minutes}`;
 
   return formattedTime;
+};
+
+// 시간 비교를 위한 함수
+const timeToMinutes = (time: string) => {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+// 예약한 시간이 다음 날 일때 업체 시작시간과 비교하여 작다면 다음날로 변환
+export const convertToNextDayIfNextDay = (
+  reservationStartTime: string,
+  clubStartTime: string,
+  date: string
+) => {
+  if (timeToMinutes(reservationStartTime) < timeToMinutes(clubStartTime)) {
+    const newDate = new Date(date.slice(0, 10));
+    console.log('newDate', newDate);
+    const returnNextDay = format(
+      new Date(newDate.setDate(newDate.getDate() + 1)),
+      'yyyy-MM-dd'
+    );
+    console.log('returnNextDay', returnNextDay);
+    return `${returnNextDay}T00:00:00`;
+  }
+  return date;
 };


### PR DESCRIPTION
## 🕹️ 개요
사소한 수정

## 🔎 작업 사항
- 예약한 시작시간을 업체의 시작시간과 비교하여 작다면 이는 다음 날일 것임으로 다음 날로 변환
- 예약 2단계에서 헤더의 `X`버튼 누르면 1단계로 이동해 다시 예약할 때 1단계를 확인할 수 있도록 수정
- 정보를 수정하고 버튼을 클릭하면 input이 포커싱을 잃어 onBlur가 발생하는데 이를 button에 onMouseDown를 통해 방지
- 시간당 게임 예약 시 타임슬롯의 오전/오후 표기가 정확하지 않아 이를 올바르게 수정

## 📋 작업 브랜치
Fix/trivial3