### PR TITLE
[Feat] : 

### DIFF
--- a/src/apis/discord/sendBackendCancelFailMessageToDiscord.ts
+++ b/src/apis/discord/sendBackendCancelFailMessageToDiscord.ts
@@ -1,0 +1,31 @@
+const handleSendTigCancelFailToDiscord = async (
+  reservationId: number,
+  paymentId: string
+) => {
+  try {
+    const discordMessage = {
+      username: 'tig 백엔드 예약 취소 실패 알림',
+      content:
+        '포트원 결제 취소는 성공했지만 TIG 백엔드에서의 예약 취소 실패로 인한 알림입니다!',
+      embeds: [
+        {
+          description: `백엔드에서의 예약 취소 실패입니다. 예약 번호는 ${reservationId}이며, 포트원 결제 id는 ${paymentId}입니다.`,
+        },
+      ],
+    };
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_DISCORD_CANCELLATION_FAIL_URL}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify(discordMessage),
+      }
+    );
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default handleSendTigCancelFailToDiscord;

--- a/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/page.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'next/navigation';
 import cancelPortOnePayment from '@apis/portone/cancelPayment';
 import { useDeleteUserSpecificReservation } from '@apis/reservation-list/reservation/deleteUserSpecificReservation';
 import { useQueryClient } from '@tanstack/react-query';
+import handleSendTigCancelFailToDiscord from '@apis/discord/sendBackendCancelFailMessageToDiscord';
 
 export default function Page() {
   const [historyHeadState, setHistoryHeadState] = useState<
@@ -55,6 +56,7 @@ export default function Page() {
   );
 
   const { data, isError } = useGetReservationList();
+
   const cancelReservationMutation = useDeleteUserSpecificReservation();
 
   const router = useRouter();
@@ -264,6 +266,10 @@ export default function Page() {
                         router.replace('/');
                       } else {
                         // Discord로 기획 쪽에 알리는 로직
+                        handleSendTigCancelFailToDiscord(
+                          cancelReservationId as number,
+                          cancelPaymentId as string
+                        );
                       }
                     },
                   }

--- a/src/components/reservation-list/reservation/ReservationCancelSection.tsx
+++ b/src/components/reservation-list/reservation/ReservationCancelSection.tsx
@@ -4,6 +4,7 @@ import { useGetUserSpecificReservationInfo } from '@apis/reservation-list/reserv
 import { useDeleteUserSpecificReservation } from '@apis/reservation-list/reservation/deleteUserSpecificReservation';
 import cancelPortOnePayment from '@apis/portone/cancelPayment';
 import { useQueryClient } from '@tanstack/react-query';
+import handleSendTigCancelFailToDiscord from '@apis/discord/sendBackendCancelFailMessageToDiscord';
 
 interface ReservationCancelProps {
   cancelAvailableDate: string;
@@ -61,6 +62,10 @@ export default function ReservationCancelSection({
                       router.replace('/');
                     } else {
                       // Discord로 기획 쪽에 알리는 로직
+                      handleSendTigCancelFailToDiscord(
+                        parseInt(reservationId as string),
+                        paymentId
+                      );
                     }
                   },
                 }


### PR DESCRIPTION
사용자 포트원 결제 취소 성공 후 백엔드 예약 취소 실패 시 이에 대한 reservationId와 paymentId를 디스코드 예약취소 - 문제발생 채널로 전송

-> 일단 이건 특수한 상황에서 벌어지는 일이므로, 내가 예약 취소상황에서 해당 채널로 메시지가 잘 날라가나 테스트해봤는데 잘 됐고, 로직도 알맞은 곳에 넣어두었음!

관련 환경변수 카톡으로 전해줄게! 그리고 vercel에도 적용시켜놓을겡