### PR TITLE
Fix/trivial4

### DIFF
--- a/src/apis/search/getLoginUserSearchedResult.ts
+++ b/src/apis/search/getLoginUserSearchedResult.ts
@@ -1,5 +1,5 @@
 import { instance } from '@apis/instance';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { ResultCardProps } from 'types/search/result/searchResult';
 
 export interface SearchResearchResponse {
@@ -22,7 +22,7 @@ export const getLoginUserSearchedResult = async (
 };
 
 export const useGetLoginUserSearchedResult = (search: string) => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['loginUserSearchedResult', search], // search를 queryKey에 포함
     queryFn: ({ queryKey }) => {
       const searchParam = queryKey[1] as string; // search 인수 추출

--- a/src/apis/search/getLoginUserSearchedResult.ts
+++ b/src/apis/search/getLoginUserSearchedResult.ts
@@ -2,11 +2,12 @@ import { instance } from '@apis/instance';
 import { useQuery } from '@tanstack/react-query';
 import { ResultCardProps } from 'types/search/result/searchResult';
 
-interface SearchResearchResponse {
+export interface SearchResearchResponse {
   result: {
     searchList: ResultCardProps[];
     avgLatitude: number;
     avgLongitude: number;
+    isResult: boolean;
   };
   resultCode: number;
   resultMsg: string;

--- a/src/apis/search/getUnLoginUserSearchedResult.ts
+++ b/src/apis/search/getUnLoginUserSearchedResult.ts
@@ -1,5 +1,5 @@
 import { instance } from '@apis/instance';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { ResultCardProps } from 'types/search/result/searchResult';
 import { SearchResearchResponse } from './getLoginUserSearchedResult';
 
@@ -18,7 +18,7 @@ export const getUnLoginUserSearchedResult = async (
 };
 
 export const useGetUnLoginUserSearchedResult = (search: string) => {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ['unLoginUserSearchedResult', search], // search를 queryKey에 포함
     queryFn: ({ queryKey }) => {
       const searchParam = queryKey[1] as string; // search 인수 추출

--- a/src/apis/search/getUnLoginUserSearchedResult.ts
+++ b/src/apis/search/getUnLoginUserSearchedResult.ts
@@ -1,16 +1,7 @@
 import { instance } from '@apis/instance';
 import { useQuery } from '@tanstack/react-query';
 import { ResultCardProps } from 'types/search/result/searchResult';
-
-interface SearchResearchResponse {
-  result: {
-    searchList: ResultCardProps[];
-    avgLatitude: number;
-    avgLongitude: number;
-  };
-  resultCode: number;
-  resultMsg: string;
-}
+import { SearchResearchResponse } from './getLoginUserSearchedResult';
 
 export const getUnLoginUserSearchedResult = async (
   search: string

--- a/src/app/(NavBarCommonLayout)/search/result/layout.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/layout.tsx
@@ -1,6 +1,7 @@
 import TigLoadingPage from '@components/all/TigLoadingPage';
+import CustomSuspense from '@providers/CustomSuspense';
 import { PropsWithChildren, Suspense } from 'react';
 
 export default function Layout({ children }: PropsWithChildren) {
-  return <Suspense fallback={<TigLoadingPage />}>{children}</Suspense>;
+  return <CustomSuspense fallback={<TigLoadingPage />}>{children}</CustomSuspense>;
 }

--- a/src/app/(NavBarCommonLayout)/search/result/layout.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/layout.tsx
@@ -1,0 +1,6 @@
+import TigLoadingPage from '@components/all/TigLoadingPage';
+import { PropsWithChildren, Suspense } from 'react';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return <Suspense fallback={<TigLoadingPage />}>{children}</Suspense>;
+}

--- a/src/app/(NavBarCommonLayout)/search/result/page.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/page.tsx
@@ -1,10 +1,75 @@
-import { Suspense } from 'react';
-import { SearchResult } from './SearchResult';
+'use client';
+import SearchHeader from '@components/all/SearchHeader';
+import Tabs from '@components/all/Tabs/Tabs';
+import BottomSheet from '@components/search/result/BottomSheet';
+import FilterHeader from '@components/search/result/FilterHeader';
+import NaverMap from '@components/search/result/NaverMap';
+import NoSearchResult from '@components/search/result/NoSearchResult';
+import PinCard from '@components/search/result/PinCard';
+import { allleisureArray } from '@constant/constant';
+import { formatDate, parse } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { useSearchParams } from 'next/navigation';
+import { useSearchResult } from '@hooks/search/result/useSearchResult';
+
+const isResult = true;
 
 export default function Page() {
+  const tabArray = allleisureArray;
+  const searchParams = useSearchParams();
+  const { search, date, adultCount, teenagerCount, kidsCount } =
+    Object.fromEntries(searchParams.entries());
+  const parsedDate = parse(date, "yyyy-MM-dd'T'HH:mm:ss", new Date());
+  const formattedDate = formatDate(parsedDate, 'M.dd (EEE)', { locale: ko });
+  const {
+    currentLocation,
+    filteredSearchResult,
+    handleMyLocation,
+    pinCardIndex,
+    isBottomSheetOpen,
+  } = useSearchResult(search);
+
   return (
-    <Suspense>
-      <SearchResult />
-    </Suspense>
+    <main className="w-full h-full flex justify-center items-center text-[200px]">
+      <SearchHeader
+        result
+        placeholder={`${search}, ${formattedDate}${
+          adultCount === '0' ? '' : `, 성인 ${adultCount}명`
+        }${teenagerCount === '0' ? '' : `, 청소년 ${teenagerCount}명`}${
+          kidsCount === '0' ? '' : `, 어린이 ${kidsCount}명 `
+        }`}
+        isHomeOrResultPage
+      />
+      <Tabs
+        tabArray={tabArray}
+        rounded
+        from="search"
+        className="w-full px-5 top-[58px]"
+      />
+      <FilterHeader />
+      {isResult && (
+        <NaverMap
+          locationArray={filteredSearchResult.map((result) => ({
+            latitude: result.latitude || 0,
+            longitude: result.longitude || 0,
+          }))}
+          currentLatitude={currentLocation.latitude}
+          currentLongitude={currentLocation.longitude}
+        />
+      )}
+      {isResult && isBottomSheetOpen && (
+        <BottomSheet
+          results={filteredSearchResult}
+          handleMyLocation={handleMyLocation}
+        />
+      )}
+      {!isBottomSheetOpen && (
+        <PinCard
+          PinCard={filteredSearchResult[pinCardIndex]}
+          handleMyLocation={handleMyLocation}
+        />
+      )}
+      {!isResult && <NoSearchResult />}
+    </main>
   );
 }

--- a/src/app/(NavBarCommonLayout)/search/result/page.tsx
+++ b/src/app/(NavBarCommonLayout)/search/result/page.tsx
@@ -12,8 +12,6 @@ import { ko } from 'date-fns/locale';
 import { useSearchParams } from 'next/navigation';
 import { useSearchResult } from '@hooks/search/result/useSearchResult';
 
-const isResult = true;
-
 export default function Page() {
   const tabArray = allleisureArray;
   const searchParams = useSearchParams();
@@ -27,6 +25,8 @@ export default function Page() {
     handleMyLocation,
     pinCardIndex,
     isBottomSheetOpen,
+    isResult,
+    recommendedResult,
   } = useSearchResult(search);
 
   return (
@@ -69,7 +69,7 @@ export default function Page() {
           handleMyLocation={handleMyLocation}
         />
       )}
-      {!isResult && <NoSearchResult />}
+      {!isResult && <NoSearchResult results={recommendedResult} />}
     </main>
   );
 }

--- a/src/components/mypage/My.tsx
+++ b/src/components/mypage/My.tsx
@@ -17,13 +17,14 @@ export default function My() {
       <div className="w-eightNineWidth mypageWidth h-fit flex flex-col items-center gap-y-[30px] mb-[30px]">
         {/* <MyProfileDefaultImage /> */}
         {data.result.profileImage ? (
-          <Image
-            src={data.result.profileImage}
-            alt="프로필 이미지"
-            className="rounded-[50%]"
-            width={80}
-            height={80}
-          />
+          <div className="relative w-[80px] h-[80px] rounded-full overflow-hidden">
+            <Image
+              src={data.result.profileImage}
+              alt="프로필 이미지"
+              className="object-cover"
+              layout="fill"
+            />
+          </div>
         ) : (
           <MyProfileDefaultImage />
         )}

--- a/src/components/search/Calender.tsx
+++ b/src/components/search/Calender.tsx
@@ -61,11 +61,20 @@ export default function Calender() {
     } else {
       setSearchInputInfo({ ...searchInputInfo, searchDate: formattedDate });
     }
-    
+
     if (date.getMonth() < calendarMonth.getMonth()) {
-      setCalendarMonth(subMonths(calendarMonth, 1));
+      if (date.getMonth() === 0) {
+        setCalendarMonth(addMonths(calendarMonth, 1));
+      } else {
+        setCalendarMonth(subMonths(calendarMonth, 1));
+      }
     } else if (date.getMonth() > calendarMonth.getMonth()) {
-      setCalendarMonth(addMonths(calendarMonth, 1));
+      if (date.getMonth() === 11) {
+        console.log(date.getMonth(), calendarMonth.getMonth());
+        setCalendarMonth(subMonths(calendarMonth, 1));
+      } else {
+        setCalendarMonth(addMonths(calendarMonth, 1));
+      }
     }
     setSelectedDate(formattedDate);
   };

--- a/src/components/search/Calender.tsx
+++ b/src/components/search/Calender.tsx
@@ -50,7 +50,7 @@ export default function Calender() {
   };
   const calendarList = createCalendarList(calendarMonth);
   const handleClickDate = (date: Date) => {
-    if (date < subDays(new Date(), 1)){
+    if (date < subDays(new Date(), 1)) {
       return;
     }
     const formattedDate = formatDate(date, "yyyy-MM-dd'T'HH:mm:ss");
@@ -60,6 +60,12 @@ export default function Calender() {
       setTimeReservationInfo({ ...timeReservationInfo, date: formattedDate });
     } else {
       setSearchInputInfo({ ...searchInputInfo, searchDate: formattedDate });
+    }
+    
+    if (date.getMonth() < calendarMonth.getMonth()) {
+      setCalendarMonth(subMonths(calendarMonth, 1));
+    } else if (date.getMonth() > calendarMonth.getMonth()) {
+      setCalendarMonth(addMonths(calendarMonth, 1));
     }
     setSelectedDate(formattedDate);
   };
@@ -112,8 +118,10 @@ export default function Calender() {
                     className={cn(
                       'w-[44px] h-[44px] grey6 flex justify-center items-center cursor-pointer body2',
                       {
-                        'rounded-full bg-primary_orange1 text-white': isSelected,
-                        'text-grey3': day.getMonth() !== calendarMonth.getMonth() || isPast,
+                        'rounded-full bg-primary_orange1 text-white':
+                          isSelected,
+                        'text-grey3':
+                          day.getMonth() !== calendarMonth.getMonth() || isPast,
                         'line-through': isPast,
                         'cursor-not-allowed': isPast,
                       }

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -56,7 +56,6 @@ export default function SearchModal() {
   }, [isModalOpen]);
 
   useEffect(() => {
-    setModal(true);
     if (localStorage.getItem('accessToken')) {
       if (data) {
         setRecentSearch(data.result);

--- a/src/components/search/result/BottomSheet.tsx
+++ b/src/components/search/result/BottomSheet.tsx
@@ -59,10 +59,10 @@ export default function BottomSheet({
           )}
           {results.map((result, idx) => {
             if(idx === 0)
-              return <ResultCard key={result.clubName} {...result} isFirst />
+              return <ResultCard key={result.clubId} {...result} isFirst />
             if (idx === results.length - 1)
-              return <ResultCard key={result.clubName} {...result} isLast />;
-            return <ResultCard key={result.clubName} {...result} />;
+              return <ResultCard key={result.clubId} {...result} isLast />;
+            return <ResultCard key={result.clubId} {...result} />;
           })}
         </Sheet.Content>
       </Sheet.Container>

--- a/src/components/search/result/NoSearchResult.tsx
+++ b/src/components/search/result/NoSearchResult.tsx
@@ -1,37 +1,11 @@
 import { ResultCardProps } from 'types/search/result/searchResult';
 import ResultCard from './ResultCard';
 
-const DUMMYRESULTS: ResultCardProps[] = [
-  {
-    clubName: '스카이락볼링장1',
-    id: 1,
-    address: '서울특별시 강남구 역삼동',
-    ratingSum: 4.5,
-    ratingCount: 100,
-    price: 10000,
-    type: 'GAME',
-    isEvent: true,
-    imageUrls: ['/png/dummyImage.png'],
-    category: 'BALLING',
-    avgRating: 4.5,
-  },
-  {
-    clubName: '스카이락볼링장2',
-    id: 2,
-    address:
-      '서울특별시 강남구 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동 역삼동',
-    ratingSum: 4.5,
-    ratingCount: 100,
-    price: 10000,
-    type: 'GAME',
-    isHeart: true,
-    imageUrls: ['/png/dummyImage.png'],
-    category: 'BALLING',
-    avgRating: 4.5,
-  },
-];
+interface NoSearchResultProps {
+  results: ResultCardProps[];
+}
 
-export default function NoSearchResult() {
+export default function NoSearchResult({ results }: NoSearchResultProps) {
   return (
     <section className="w-full h-full">
       <div className="pt-[200px] flex flex-col gap-[10px] justify-center items-center">
@@ -39,8 +13,8 @@ export default function NoSearchResult() {
       </div>
       <div className="w-full flex flex-col gap5 pt-[62px]">
         <p className="headline2 text-grey7 px-5 ">이런 곳은 어때요?</p>
-        <ResultCard {...DUMMYRESULTS[0]} />
-        <ResultCard {...DUMMYRESULTS[1]} />
+        <ResultCard {...results[0]} />
+        <ResultCard {...results[1]} />
       </div>
     </section>
   );

--- a/src/components/search/result/ResultCard.tsx
+++ b/src/components/search/result/ResultCard.tsx
@@ -30,7 +30,6 @@ export default function ResultCard({
 }: ResultCardProps) {
   const router = useRouter();
   const [isHeartClicked, setIsHeartClicked] = useState(isHeart);
-  console.log(isHeartClicked);
   const { mutate: deleteFromWishList } = useDeleteFromWishList();
   const { mutate: addToWishList } = useAddToWishList();
   const handleFillHeartClick = (e: React.MouseEvent<SVGSVGElement>) => {

--- a/src/hooks/search/result/useSearchResult.ts
+++ b/src/hooks/search/result/useSearchResult.ts
@@ -1,29 +1,14 @@
-'use client';
 import { useGetLoginUserSearchedResult } from '@apis/search/getLoginUserSearchedResult';
-import NavBar from '@components/all/NavBar/NavBar';
-import SearchHeader from '@components/all/SearchHeader';
-import Tabs from '@components/all/Tabs/Tabs';
-import BottomSheet from '@components/search/result/BottomSheet';
-import FilterHeader from '@components/search/result/FilterHeader';
-import NaverMap from '@components/search/result/NaverMap';
-import NoSearchResult from '@components/search/result/NoSearchResult';
-import PinCard from '@components/search/result/PinCard';
-import ResultCard from '@components/search/result/ResultCard';
-import { allleisureArray, categoryMapEngToKor } from '@constant/constant';
+import { useGetUnLoginUserSearchedResult } from '@apis/search/getUnLoginUserSearchedResult';
+import { categoryMapEngToKor } from '@constant/constant';
 import { useBottomSheetStore } from '@store/bottomSheetStore';
 import { useFilterOptionStore } from '@store/filterOptionStore';
 import { usePinCardIndexStore } from '@store/pinCardIndexStore';
 import useTab from '@store/tabNumberStore';
-import { formatDate, parse } from 'date-fns';
-import { ko } from 'date-fns/locale';
-import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { ResultCardProps } from 'types/search/result/searchResult';
-import { useGetUnLoginUserSearchedResult } from '@apis/search/getUnLoginUserSearchedResult';
 
-const isResult = true;
-
-export function SearchResult() {
+export const useSearchResult = (search: string) => {
   const [filteredSearchResult, setFilteredSearchResult] = useState<
     ResultCardProps[]
   >([]);
@@ -31,10 +16,6 @@ export function SearchResult() {
   const [originalSearchResult, setOriginalSearchResult] = useState<
     ResultCardProps[]
   >([]);
-  const tabArray = allleisureArray;
-  const isBottomSheetOpen = useBottomSheetStore(
-    (state) => state.isBottomSheetOpen
-  );
   const pinCardIndex = usePinCardIndexStore((state) => state.pinCardIndex);
   const setIsBottomSheetOpen = useBottomSheetStore(
     (state) => state.setIsBottomSheetOpen
@@ -43,11 +24,9 @@ export function SearchResult() {
     latitude: 37.55527,
     longitude: 126.9366,
   });
-  const searchParams = useSearchParams();
-  const { search, date, adultCount, teenagerCount, kidsCount } =
-    Object.fromEntries(searchParams.entries());
-  const parsedDate = parse(date, "yyyy-MM-dd'T'HH:mm:ss", new Date());
-  const formattedDate = formatDate(parsedDate, 'M.dd (EEE)', { locale: ko });
+  const isBottomSheetOpen = useBottomSheetStore(
+    (state) => state.isBottomSheetOpen
+  );
   const { data: loginUserSearchResult } = useGetLoginUserSearchedResult(search);
   const { data: unLoginUserSearchResult } =
     useGetUnLoginUserSearchedResult(search);
@@ -113,49 +92,16 @@ export function SearchResult() {
     });
   };
 
-  console.log(filteredSearchResult);
-
-  return (
-    <div className="w-full h-full flex justify-center items-center text-[200px]">
-      <SearchHeader
-        result
-        placeholder={`${search}, ${formattedDate}${
-          adultCount === '0' ? '' : `, 성인 ${adultCount}명`
-        }${teenagerCount === '0' ? '' : `, 청소년 ${teenagerCount}명`}${
-          kidsCount === '0' ? '' : `, 어린이 ${kidsCount}명 `
-        }`}
-        isHomeOrResultPage
-      />
-      <Tabs
-        tabArray={tabArray}
-        rounded
-        from="search"
-        className="w-full px-5 top-[58px]"
-      />
-      <FilterHeader />
-      {isResult && (
-        <NaverMap
-          locationArray={filteredSearchResult.map((result) => ({
-            latitude: result.latitude || 0,
-            longitude: result.longitude || 0,
-          }))}
-          currentLatitude={currentLocation.latitude}
-          currentLongitude={currentLocation.longitude}
-        />
-      )}
-      {isResult && isBottomSheetOpen && (
-        <BottomSheet
-          results={filteredSearchResult}
-          handleMyLocation={handleMyLocation}
-        />
-      )}
-      {!isBottomSheetOpen && (
-        <PinCard
-          PinCard={filteredSearchResult[pinCardIndex]}
-          handleMyLocation={handleMyLocation}
-        />
-      )}
-      {!isResult && <NoSearchResult />}
-    </div>
-  );
-}
+  return {
+    filteredSearchResult,
+    setFilteredSearchResult,
+    selectedOption,
+    originalSearchResult,
+    setOriginalSearchResult,
+    pinCardIndex,
+    currentLocation,
+    setCurrentLocation,
+    handleMyLocation,
+    isBottomSheetOpen,
+  };
+};

--- a/src/hooks/search/result/useSearchResult.ts
+++ b/src/hooks/search/result/useSearchResult.ts
@@ -9,6 +9,10 @@ import { useEffect, useState } from 'react';
 import { ResultCardProps } from 'types/search/result/searchResult';
 
 export const useSearchResult = (search: string) => {
+  const [isResult, setIsResult] = useState(false);
+  const [recommendedResult, setRecommendedResult] = useState<ResultCardProps[]>(
+    []
+  );
   const [filteredSearchResult, setFilteredSearchResult] = useState<
     ResultCardProps[]
   >([]);
@@ -38,12 +42,20 @@ export const useSearchResult = (search: string) => {
         longitude: loginUserSearchResult?.result.avgLongitude || 126.9366,
       });
       setOriginalSearchResult(loginUserSearchResult?.result.searchList || []);
+      setIsResult(loginUserSearchResult?.result.isResult || false);
+      if (!loginUserSearchResult?.result.isResult) {
+        setRecommendedResult(loginUserSearchResult?.result.searchList || []);
+      }
     } else {
       setCurrentLocation({
         latitude: unLoginUserSearchResult?.result.avgLatitude || 37.55527,
         longitude: unLoginUserSearchResult?.result.avgLongitude || 126.9366,
       });
       setOriginalSearchResult(unLoginUserSearchResult?.result.searchList || []);
+      setIsResult(unLoginUserSearchResult?.result.isResult || false);
+      if (!unLoginUserSearchResult?.result.isResult) {
+        setRecommendedResult(unLoginUserSearchResult?.result.searchList || []);
+      }
     }
   }, [loginUserSearchResult, unLoginUserSearchResult]);
 
@@ -94,14 +106,13 @@ export const useSearchResult = (search: string) => {
 
   return {
     filteredSearchResult,
-    setFilteredSearchResult,
     selectedOption,
     originalSearchResult,
-    setOriginalSearchResult,
     pinCardIndex,
     currentLocation,
-    setCurrentLocation,
-    handleMyLocation,
     isBottomSheetOpen,
+    isResult,
+    recommendedResult,
+    handleMyLocation,
   };
 };


### PR DESCRIPTION
## 🕹️ 개요
사소한 수정

## 🔎 작업 사항
- 달력에서 다음 달에 있는 날짜 클릭하면 다음 달로 바뀌도록 구현
- 검색페이지 접근 시 모달 바로 안 열리도록 수정
- 업체이름이 중복되는 경우가 있어서 map의 key를 주소 변경 ( 근데 주소가 겹치면? )
- 검색페이지 필터링 제대로 동작하도록 구현
- 검색결과 페이지 API 훅 분리
- 검색결과가 없을 때 랜덤으로 2개의 지역을 가져와서 렌더링
- 검색결과 API useSuspenseQuery 적용
  위시리스트와 다르게 받아온 API응답을 무조건 사용하는게 아니라 처음에는 더미값을 입력, 비로그인/로그인 API를 둘다 호출하고 AT 여부로 무슨 응답을 사용할지 결정하는 방식으로 구현해서 useQuery를 사용해도 되겠다 생각했음. 하지만 렌더링해보니 처음 더미값때문에 검색결과 없음 페이지가 렌더링 되었다가 API 호출, AT 여부 확인 후 리렌더링 됨. 이를 방지하기 위해 useSuspenseQuery를 사용해 defined된 응답이 오기 전까지 fallback으로 로딩UI를 띄워줌
- 지금 발생하는 이슈로 검색결과페이지 처음 접근 시 핑이 안보임. 필터링하면 보이는데 처음 렌더링될 때 보이지 않음 -> 해결
- home API 변경된 거 연결

## 📋 작업 브랜치
Fix/trivial4