### PR TITLE
[Fix] : 예약 내역에서 진행중, 종료된의 컴포넌트에도 imageUrls 제공

### DIFF
--- a/src/app/(NavBarCommonLayout)/reservation-list/(reservation-list-page)/page.tsx
+++ b/src/app/(NavBarCommonLayout)/reservation-list/(reservation-list-page)/page.tsx
@@ -171,6 +171,7 @@ export default function Page() {
                     paymentId={data.paymentId}
                     handleChangeCancelPaymentId={setCancelPaymentId}
                     handleChangeCancelReservationId={setCancelReservationId}
+                    imageUrls={data.imageUrls}
                   />
                 ))}
               </main>
@@ -200,6 +201,7 @@ export default function Page() {
                   reservationStatus={data.status}
                   reservationId={data.reservationId}
                   reviewId={data.reviewId}
+                  imageUrls={data.imageUrls}
                 />
               ))}
             </main>


### PR DESCRIPTION
## 🕹️ 개요

## 🔎 작업 사항
빼먹고 있었음; ㅈㅅ

## 📋 작업 브랜치
